### PR TITLE
Remove GT_STMT usage from the code generator.

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -163,6 +163,7 @@ private:
     void                genGenerateStackProbe();
 #endif
 
+#ifdef LEGACY_BACKEND
     regMaskTP           genNewLiveRegMask   (GenTreePtr first, GenTreePtr second);
 
     // During codegen, determine the LiveSet after tree.
@@ -170,6 +171,7 @@ private:
     // compCurLifeTree are being maintained, and tree must occur in the current
     // statement.
     VARSET_VALRET_TP    genUpdateLiveSetForward(GenTreePtr tree);
+#endif
 
     //-------------------------------------------------------------------------
 

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -182,7 +182,6 @@ void                CodeGen::genCodeForBBlist()
 
 #ifdef  DEBUG
     genInterruptibleUsed        = true;
-    unsigned        stmtNum     = 0;
     unsigned        totalCostEx = 0;
     unsigned        totalCostSz = 0;
 
@@ -351,13 +350,12 @@ void                CodeGen::genCodeForBBlist()
 
         if (handlerGetsXcptnObj(block->bbCatchTyp))
         {
-            GenTreePtr firstStmt = block->FirstNonPhiDef();
-            if (firstStmt != NULL)
+            for (GenTree* node : LIR::AsRange(block))
             {
-                GenTreePtr firstTree = firstStmt->gtStmt.gtStmtExpr;
-                if (compiler->gtHasCatchArg(firstTree))
+                if (node->OperGet() == GT_CATCH_ARG)
                 {
                     gcInfo.gcMarkRegSetGCref(RBM_EXCEPTION_OBJECT);
+                    break;
                 }
             }
         }
@@ -487,96 +485,66 @@ void                CodeGen::genCodeForBBlist()
         }
 #endif // FEATURE_EH_FUNCLETS
 
-        for (GenTreePtr stmt = block->FirstNonPhiDef(); stmt; stmt = stmt->gtNext)
+        // Clear compCurStmt and compCurLifeTree.
+        compiler->compCurStmt = nullptr;
+        compiler->compCurLifeTree = nullptr;
+
+#ifdef DEBUG
+        bool pastProfileUpdate = false;
+#endif
+
+        // Traverse the block in linear order, generating code for each node as we
+        // as we encounter it.
+#ifdef DEBUGGING_SUPPORT
+        IL_OFFSETX currentILOffset = BAD_IL_OFFSET;
+#endif
+        for (GenTree* node : LIR::AsRange(block))
         {
-            noway_assert(stmt->gtOper == GT_STMT);
-
-            if (stmt->AsStmt()->gtStmtIsEmbedded())
-                continue;
-
-            /* Get hold of the statement tree */
-            GenTreePtr  tree = stmt->gtStmt.gtStmtExpr;
-
-#if defined(DEBUGGING_SUPPORT)
-
-            /* Do we have a new IL-offset ? */
-
-            if (stmt->gtStmt.gtStmtILoffsx != BAD_IL_OFFSET)
+#ifdef DEBUGGING_SUPPORT
+            // Do we have a new IL offset?
+            if (node->OperGet() == GT_IL_OFFSET)
             {
-                /* Create and append a new IP-mapping entry */
-                genIPmappingAdd(stmt->gtStmt.gtStmt.gtStmtILoffsx, firstMapping);
+                genEnsureCodeEmitted(currentILOffset);
+
+                currentILOffset = node->gtStmt.gtStmtILoffsx;
+
+                genIPmappingAdd(currentILOffset, firstMapping);
                 firstMapping = false;
             }
-
 #endif // DEBUGGING_SUPPORT
 
 #ifdef DEBUG
-            noway_assert(stmt->gtStmt.gtStmtLastILoffs <= compiler->info.compILCodeSize ||
-                         stmt->gtStmt.gtStmtLastILoffs == BAD_IL_OFFSET);
-
-            if (compiler->opts.dspCode && compiler->opts.dspInstrs &&
-                stmt->gtStmt.gtStmtLastILoffs != BAD_IL_OFFSET)
+            if (node->OperGet() == GT_IL_OFFSET)
             {
-                while (genCurDispOffset <= stmt->gtStmt.gtStmtLastILoffs)
+                noway_assert(node->gtStmt.gtStmtLastILoffs <= compiler->info.compILCodeSize ||
+                             node->gtStmt.gtStmtLastILoffs == BAD_IL_OFFSET);
+
+                if (compiler->opts.dspCode && compiler->opts.dspInstrs &&
+                    node->gtStmt.gtStmtLastILoffs != BAD_IL_OFFSET)
                 {
-                    genCurDispOffset +=
-                        dumpSingleInstr(compiler->info.compCode, genCurDispOffset, ">    ");
+                    while (genCurDispOffset <= node->gtStmt.gtStmtLastILoffs)
+                    {
+                        genCurDispOffset +=
+                            dumpSingleInstr(compiler->info.compCode, genCurDispOffset, ">    ");
+                    }
                 }
             }
 
-            stmtNum++;
-            if (compiler->verbose)
-            {
-                printf("\nGenerating BB%02u, stmt %u\t\t", block->bbNum, stmtNum);
-                printf("Holding variables: ");
-                dspRegMask(regSet.rsMaskVars); printf("\n\n");
-                compiler->gtDispTree(compiler->opts.compDbgInfo ? stmt : tree);
-                printf("\n");
-            }
-            totalCostEx += (stmt->gtCostEx * block->getBBWeight(compiler));
-            totalCostSz +=  stmt->gtCostSz;
+            // TODO(pdg): JIT dump, cost accounting
+
 #endif // DEBUG
 
-            // Traverse the tree in linear order, generating code for each node in the
-            // tree as we encounter it
-
-            // If we have embedded statements, we need to keep track of the next top-level
-            // node in order, because if it produces a register, we need to consume it
-
-            GenTreeStmt* curPossiblyEmbeddedStmt = stmt->gtStmt.gtStmtNextIfEmbedded();
-            if (curPossiblyEmbeddedStmt == nullptr)
-                curPossiblyEmbeddedStmt = stmt->AsStmt();
-
-            compiler->compCurLifeTree = NULL;
-            compiler->compCurStmt = stmt;
-            for (GenTreePtr treeNode = stmt->gtStmt.gtStmtList;
-                 treeNode != NULL;
-                 treeNode = treeNode->gtNext)
+            genCodeForTreeNode(node);
+            if (node->gtHasReg() && node->gtLsraInfo.isLocalDefUse)
             {
-                genCodeForTreeNode(treeNode);
-
-                if (treeNode == curPossiblyEmbeddedStmt->gtStmtExpr)
-                {
-                    // It is possible that the last top-level node may generate a result
-                    // that is not used (but may still require a register, e.g. an indir
-                    // that is evaluated only for the side-effect of a null check).
-                    // In that case, we must "consume" the register now.
-                    if (treeNode->gtHasReg())
-                    {
-                        genConsumeReg(treeNode);
-                    }
-                    if (curPossiblyEmbeddedStmt != stmt)
-                    {
-                        curPossiblyEmbeddedStmt = curPossiblyEmbeddedStmt->gtStmt.gtStmtNextIfEmbedded();
-                        if (curPossiblyEmbeddedStmt == nullptr)
-                            curPossiblyEmbeddedStmt = stmt->AsStmt();
-                    }
-                }
+                genConsumeReg(node);
             }
 
+#ifdef DEBUG
             regSet.rsSpillChk();
 
-#ifdef DEBUG
+            assert((node->gtFlags & GTF_SPILL) == 0);
+
             /* Make sure we didn't bungle pointer register tracking */
 
             regMaskTP ptrRegs       = (gcInfo.gcRegGCrefSetCur|gcInfo.gcRegByrefSetCur);
@@ -587,28 +555,28 @@ void                CodeGen::genCodeForBBlist()
             // even though we might return a ref.  We can't use the compRetType
             // as the determiner because something we are tracking as a byref
             // might be used as a return value of a int function (which is legal)
-            if  (tree->gtOper == GT_RETURN &&
+            if  (node->gtOper == GT_RETURN &&
                 (varTypeIsGC(compiler->info.compRetType) ||
-                    (tree->gtOp.gtOp1 != 0 && varTypeIsGC(tree->gtOp.gtOp1->TypeGet()))))
+                    (node->gtOp.gtOp1 != 0 && varTypeIsGC(node->gtOp.gtOp1->TypeGet()))))
             {
                 nonVarPtrRegs &= ~RBM_INTRET;
             }
 
-            // When profiling, the first statement in a catch block will be the
-            // harmless "inc" instruction (does not interfere with the exception
-            // object).
-
-            if ((compiler->opts.eeFlags & CORJIT_FLG_BBINSTR) &&
-                (stmt == block->bbTreeList) &&
-                handlerGetsXcptnObj(block->bbCatchTyp))
+            // When profiling, the first few nodes in a catch block will be an update of
+            // the profile count (does not interfere with the exception object).
+            if (((compiler->opts.eeFlags & CORJIT_FLG_BBINSTR) != 0) && handlerGetsXcptnObj(block->bbCatchTyp))
             {
-                nonVarPtrRegs &= ~RBM_EXCEPTION_OBJECT;
+                pastProfileUpdate = pastProfileUpdate || node->OperGet() == GT_CATCH_ARG;
+                if (!pastProfileUpdate)
+                {
+                    nonVarPtrRegs &= ~RBM_EXCEPTION_OBJECT;
+                }
             }
 
             if  (nonVarPtrRegs)
             {
-                printf("Regset after tree=");
-                Compiler::printTreeID(tree);
+                printf("Regset after node=");
+                Compiler::printTreeID(node);
                 printf(" BB%02u gcr=", block->bbNum);
                 printRegMaskInt(gcInfo.gcRegGCrefSetCur & ~regSet.rsMaskVars);
                 compiler->getEmitter()->emitDispRegSet(gcInfo.gcRegGCrefSetCur & ~regSet.rsMaskVars);
@@ -622,21 +590,8 @@ void                CodeGen::genCodeForBBlist()
             }
 
             noway_assert(nonVarPtrRegs == 0);
-
-            for (GenTree * node = stmt->gtStmt.gtStmtList; node; node=node->gtNext)
-            {
-                assert(!(node->gtFlags & GTF_SPILL));
-            }
-
 #endif // DEBUG
-
-            noway_assert(stmt->gtOper == GT_STMT);
-
-#ifdef DEBUGGING_SUPPORT
-            genEnsureCodeEmitted(stmt->gtStmt.gtStmtILoffsx);
-#endif
-
-        } //-------- END-FOR each statement-tree of the current block ---------
+        }
 
 #ifdef  DEBUGGING_SUPPORT
 

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -1419,7 +1419,6 @@ void                CodeGen::genCodeForBBlist()
 
 #ifdef  DEBUG
     genInterruptibleUsed        = true;
-    unsigned        stmtNum     = 0;
     UINT64          totalCostEx = 0;
     UINT64          totalCostSz = 0;
 
@@ -1619,13 +1618,12 @@ void                CodeGen::genCodeForBBlist()
 
         if (handlerGetsXcptnObj(block->bbCatchTyp))
         {
-            GenTreePtr firstStmt = block->FirstNonPhiDef();
-            if (firstStmt != NULL)
+            for (GenTree* node : LIR::AsRange(block))
             {
-                GenTreePtr firstTree = firstStmt->gtStmt.gtStmtExpr;
-                if (compiler->gtHasCatchArg(firstTree))
+                if (node->OperGet() == GT_CATCH_ARG)
                 {
                     gcInfo.gcMarkRegSetGCref(RBM_EXCEPTION_OBJECT);
+                    break;
                 }
             }
         }
@@ -1709,78 +1707,66 @@ void                CodeGen::genCodeForBBlist()
             genReserveFuncletProlog(block);
         }
 
-        for (GenTreePtr stmt = block->FirstNonPhiDef(); stmt; stmt = stmt->gtNext)
+        // Clear compCurStmt and compCurLifeTree.
+        compiler->compCurStmt = nullptr;
+        compiler->compCurLifeTree = nullptr;
+
+#ifdef DEBUG
+        bool pastProfileUpdate = false;
+#endif
+
+        // Traverse the block in linear order, generating code for each node as we
+        // as we encounter it.
+#ifdef DEBUGGING_SUPPORT
+        IL_OFFSETX currentILOffset = BAD_IL_OFFSET;
+#endif
+        for (GenTree* node : LIR::AsRange(block))
         {
-            noway_assert(stmt->gtOper == GT_STMT);
-
-            if (stmt->AsStmt()->gtStmtIsEmbedded())
-                continue;
-
-            /* Get hold of the statement tree */
-            GenTreePtr  tree = stmt->gtStmt.gtStmtExpr;
-
-#if defined(DEBUGGING_SUPPORT)
-
-            /* Do we have a new IL-offset ? */
-
-            if (stmt->gtStmt.gtStmtILoffsx != BAD_IL_OFFSET)
+#ifdef DEBUGGING_SUPPORT
+            // Do we have a new IL offset?
+            if (node->OperGet() == GT_IL_OFFSET)
             {
-                /* Create and append a new IP-mapping entry */
-                genIPmappingAdd(stmt->gtStmt.gtStmt.gtStmtILoffsx, firstMapping);
+                genEnsureCodeEmitted(currentILOffset);
+
+                currentILOffset = node->gtStmt.gtStmtILoffsx;
+
+                genIPmappingAdd(currentILOffset, firstMapping);
                 firstMapping = false;
             }
-
 #endif // DEBUGGING_SUPPORT
 
 #ifdef DEBUG
-            noway_assert(stmt->gtStmt.gtStmtLastILoffs <= compiler->info.compILCodeSize ||
-                         stmt->gtStmt.gtStmtLastILoffs == BAD_IL_OFFSET);
-
-            if (compiler->opts.dspCode && compiler->opts.dspInstrs &&
-                stmt->gtStmt.gtStmtLastILoffs != BAD_IL_OFFSET)
+            if (node->OperGet() == GT_IL_OFFSET)
             {
-                while (genCurDispOffset <= stmt->gtStmt.gtStmtLastILoffs)
+                noway_assert(node->gtStmt.gtStmtLastILoffs <= compiler->info.compILCodeSize ||
+                             node->gtStmt.gtStmtLastILoffs == BAD_IL_OFFSET);
+
+                if (compiler->opts.dspCode && compiler->opts.dspInstrs &&
+                    node->gtStmt.gtStmtLastILoffs != BAD_IL_OFFSET)
                 {
-                    genCurDispOffset +=
-                        dumpSingleInstr(compiler->info.compCode, genCurDispOffset, ">    ");
+                    while (genCurDispOffset <= node->gtStmt.gtStmtLastILoffs)
+                    {
+                        genCurDispOffset +=
+                            dumpSingleInstr(compiler->info.compCode, genCurDispOffset, ">    ");
+                    }
                 }
             }
 
-            stmtNum++;
-            if (compiler->verbose)
-            {
-                printf("\nGenerating BB%02u, stmt %u\t\t", block->bbNum, stmtNum);
-                printf("Holding variables: ");
-                dspRegMask(regSet.rsMaskVars); printf("\n\n");
-                if (compiler->verboseTrees)
-                {
-                    compiler->gtDispTree(compiler->opts.compDbgInfo ? stmt : tree);
-                    printf("\n");
-                }
-            }
-            totalCostEx += ((UINT64)stmt->gtCostEx * block->getBBWeight(compiler));
-            totalCostSz += (UINT64) stmt->gtCostSz;
+            // TODO(pdg): JIT dump, cost accounting
+
 #endif // DEBUG
 
-            // Traverse the tree in linear order, generating code for each node in the
-            // tree as we encounter it
-
-            compiler->compCurLifeTree = NULL;
-            compiler->compCurStmt = stmt;
-            for (GenTreePtr treeNode = stmt->gtStmt.gtStmtList;
-                 treeNode != NULL;
-                 treeNode = treeNode->gtNext)
+            genCodeForTreeNode(node);
+            if (node->gtHasReg() && node->gtLsraInfo.isLocalDefUse)
             {
-                genCodeForTreeNode(treeNode);
-                if (treeNode->gtHasReg() && treeNode->gtLsraInfo.isLocalDefUse)
-                {
-                    genConsumeReg(treeNode);
-                }
+                genConsumeReg(node);
             }
 
             regSet.rsSpillChk();
 
 #ifdef DEBUG
+            assert((node->gtFlags & GTF_SPILL) == 0);
+
             /* Make sure we didn't bungle pointer register tracking */
 
             regMaskTP ptrRegs       = (gcInfo.gcRegGCrefSetCur|gcInfo.gcRegByrefSetCur);
@@ -1791,28 +1777,28 @@ void                CodeGen::genCodeForBBlist()
             // even though we might return a ref.  We can't use the compRetType
             // as the determiner because something we are tracking as a byref
             // might be used as a return value of a int function (which is legal)
-            if  (tree->gtOper == GT_RETURN &&
+            if  (node->gtOper == GT_RETURN &&
                 (varTypeIsGC(compiler->info.compRetType) ||
-                    (tree->gtOp.gtOp1 != 0 && varTypeIsGC(tree->gtOp.gtOp1->TypeGet()))))
+                    (node->gtOp.gtOp1 != 0 && varTypeIsGC(node->gtOp.gtOp1->TypeGet()))))
             {
                 nonVarPtrRegs &= ~RBM_INTRET;
             }
 
-            // When profiling, the first statement in a catch block will be the
-            // harmless "inc" instruction (does not interfere with the exception
-            // object).
-
-            if ((compiler->opts.eeFlags & CORJIT_FLG_BBINSTR) &&
-                (stmt == block->bbTreeList) &&
-                handlerGetsXcptnObj(block->bbCatchTyp))
+            // When profiling, the first few nodes in a catch block will be an update of
+            // the profile count (does not interfere with the exception object).
+            if (((compiler->opts.eeFlags & CORJIT_FLG_BBINSTR) != 0) && handlerGetsXcptnObj(block->bbCatchTyp))
             {
-                nonVarPtrRegs &= ~RBM_EXCEPTION_OBJECT;
+                pastProfileUpdate = pastProfileUpdate || node->OperGet() == GT_CATCH_ARG;
+                if (!pastProfileUpdate)
+                {
+                    nonVarPtrRegs &= ~RBM_EXCEPTION_OBJECT;
+                }
             }
 
             if  (nonVarPtrRegs)
             {
-                printf("Regset after tree=");
-                compiler->printTreeID(tree);
+                printf("Regset after node=");
+                Compiler::printTreeID(node);
                 printf(" BB%02u gcr=", block->bbNum);
                 printRegMaskInt(gcInfo.gcRegGCrefSetCur & ~regSet.rsMaskVars);
                 compiler->getEmitter()->emitDispRegSet(gcInfo.gcRegGCrefSetCur & ~regSet.rsMaskVars);
@@ -1826,21 +1812,8 @@ void                CodeGen::genCodeForBBlist()
             }
 
             noway_assert(nonVarPtrRegs == 0);
-
-            for (GenTree * node = stmt->gtStmt.gtStmtList; node; node=node->gtNext)
-            {
-                assert(!(node->gtFlags & GTF_SPILL));
-            }
-
 #endif // DEBUG
-
-            noway_assert(stmt->gtOper == GT_STMT);
-
-#ifdef DEBUGGING_SUPPORT
-            genEnsureCodeEmitted(stmt->gtStmt.gtStmtILoffsx);
-#endif
-
-        } //-------- END-FOR each statement-tree of the current block ---------
+        }
 
 #if defined(DEBUG) && defined(_TARGET_ARM64_)
         if (block->bbNext == nullptr)

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -477,6 +477,7 @@ CodeGenInterface::genUpdateLife       (VARSET_VALARG_TP newLife)
     compiler->compUpdateLife</*ForCodeGen*/true>(newLife);
 }
 
+#ifdef LEGACY_BACKEND
 // Returns the liveSet after tree has executed.
 // "tree" MUST occur in the current statement, AFTER the most recent
 // update of compiler->compCurLifeTree and compiler->compCurLife.
@@ -514,6 +515,7 @@ CodeGen::genNewLiveRegMask(GenTreePtr first, GenTreePtr second)
     regMaskTP newLiveMask = genLiveMask(VarSetOps::Diff(compiler, secondLiveSet, firstLiveSet));
     return newLiveMask;
 }
+#endif
 
 // Return the register mask for the given register variable
 // inline
@@ -1185,6 +1187,8 @@ void                Compiler::compChangeLife(VARSET_VALARG_TP newLife DEBUGARG(G
 // Need an explicit instantiation.
 template void Compiler::compChangeLife<true>(VARSET_VALARG_TP newLife DEBUGARG(GenTreePtr tree));
 
+#ifdef LEGACY_BACKEND
+
 /*****************************************************************************
  *
  *  Get the mask of integer registers that contain 'live' enregistered 
@@ -1346,6 +1350,8 @@ regMaskTP CodeGenInterface::genLiveMask(VARSET_VALARG_TP liveSet)
 
     return liveMask;
 }
+
+#endif
 
 /*****************************************************************************
  *

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -8948,12 +8948,7 @@ void                CodeGen::genFnEpilog(BasicBlock* block)
 
         /* figure out what jump we have */
 
-        GenTreePtr jmpNode = block->lastTopLevelStmt();
-
-        noway_assert(jmpNode && (jmpNode->gtNext == 0));
-        noway_assert(jmpNode->gtOper == GT_STMT);
-
-        jmpNode = jmpNode->gtStmt.gtStmtExpr;
+        GenTree* jmpNode = block->bbLastNode;
         noway_assert(jmpNode->gtOper == GT_JMP);
 
         CORINFO_METHOD_HANDLE  methHnd    = (CORINFO_METHOD_HANDLE)jmpNode->gtVal.gtVal1;
@@ -9077,18 +9072,14 @@ void                CodeGen::genFnEpilog(BasicBlock* block)
         noway_assert(block->bbTreeList != nullptr);
 
         // figure out what jump we have
-        GenTreePtr jmpStmt = block->lastTopLevelStmt();
-        noway_assert(jmpStmt && (jmpStmt->gtOper == GT_STMT));
+        GenTree* jmpNode = block->bbLastNode;
 #if !FEATURE_FASTTAILCALL
-        noway_assert(jmpStmt->gtNext == nullptr);
-        GenTreePtr jmpNode = jmpStmt->gtStmt.gtStmtExpr;
         noway_assert(jmpNode->gtOper == GT_JMP);
 #else
         // arm64
         // If jmpNode is GT_JMP then gtNext must be null.
         // If jmpNode is a fast tail call, gtNext need not be null since it could have embedded stmts.
-        GenTreePtr jmpNode = jmpStmt->gtStmt.gtStmtExpr;
-        noway_assert((jmpNode->gtOper != GT_JMP) || (jmpStmt->gtNext == nullptr));
+        noway_assert((jmpNode->gtOper != GT_JMP) || (jmpNode->gtNext == nullptr));
 
         // Could either be a "jmp method" or "fast tail call" implemented as epilog+jmp
         noway_assert((jmpNode->gtOper == GT_JMP) || ((jmpNode->gtOper == GT_CALL) && jmpNode->AsCall()->IsFastTailCall()));
@@ -9352,20 +9343,15 @@ void                CodeGen::genFnEpilog(BasicBlock* block)
         noway_assert(block->bbTreeList);
 
         // figure out what jump we have
-        GenTreePtr jmpStmt = block->lastTopLevelStmt();        
-        noway_assert(jmpStmt && (jmpStmt->gtOper == GT_STMT));
-
+        GenTree* jmpNode = block->bbLastNode;
 #if !FEATURE_FASTTAILCALL
         // x86                        
-        noway_assert(jmpStmt->gtNext == nullptr);
-        GenTreePtr jmpNode = jmpStmt->gtStmt.gtStmtExpr;
         noway_assert(jmpNode->gtOper == GT_JMP);                
 #else 
         // amd64                 
         // If jmpNode is GT_JMP then gtNext must be null.
         // If jmpNode is a fast tail call, gtNext need not be null since it could have embedded stmts.
-        GenTreePtr jmpNode = jmpStmt->gtStmt.gtStmtExpr;
-        noway_assert((jmpNode->gtOper != GT_JMP) || (jmpStmt->gtNext == nullptr)); 
+        noway_assert((jmpNode->gtOper != GT_JMP) || (jmpNode->gtNext == nullptr)); 
 
         // Could either be a "jmp method" or "fast tail call" implemented as epilog+jmp
         noway_assert((jmpNode->gtOper == GT_JMP) || ((jmpNode->gtOper == GT_CALL) && jmpNode->AsCall()->IsFastTailCall()));

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -141,8 +141,10 @@ protected:
     void                genUpdateLife       (GenTreePtr     tree);
     void                genUpdateLife       (VARSET_VALARG_TP newLife);
 
+#ifdef LEGACY_BACKEND
     regMaskTP           genLiveMask         (GenTreePtr     tree);
     regMaskTP           genLiveMask         (VARSET_VALARG_TP liveSet);
+#endif
 
     void                genGetRegPairFromMask(regMaskTP  regPairMask, regNumber* pLoReg, regNumber* pHiReg);
 

--- a/src/jit/lir.h
+++ b/src/jit/lir.h
@@ -66,10 +66,57 @@ public:
         GenTree*& LastNode() const;
 
     public:
+        class Iterator
+        {
+            friend class Range;
+
+            GenTree* m_node;
+
+            Iterator(GenTree* begin)
+                : m_node(begin)
+            {
+            }
+
+        public:
+            Iterator()
+                : m_node(nullptr)
+            {
+            }
+
+            inline GenTree* operator*()
+            {
+                return m_node;
+            }
+
+            inline GenTree* operator->()
+            {
+                return m_node;
+            }
+
+            inline bool operator==(const Iterator& other) const
+            {
+                return m_node == other.m_node;
+            }
+
+            inline bool operator!=(const Iterator& other) const
+            {
+                return m_node != other.m_node;
+            }
+
+            inline Iterator& operator++()
+            {
+                m_node = (m_node == nullptr) ? nullptr : m_node->gtNext;
+                return *this;
+            }
+        };
+
         Range();
 
         GenTree* Begin() const;
         GenTree* End() const;
+
+        Iterator begin() const;
+        Iterator end() const;
 
         bool IsValid() const;
         bool IsEmpty() const;

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2495,6 +2495,7 @@ LinearScan::getKillSetForNode(GenTree* tree)
 {
     regMaskTP killSet = getKillSetForNode(compiler, tree);
 
+#ifdef _TARGET_XARCH_
     switch (tree->OperGet())
     {
     case GT_MOD:
@@ -2519,6 +2520,7 @@ LinearScan::getKillSetForNode(GenTree* tree)
     default:
         break;
     }
+#endif
 
     return killSet;
 }

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -574,6 +574,10 @@ private:
 public:
     // Used by Lowering when considering whether to split Longs, as well as by identifyCandidates().
     bool            isRegCandidate(LclVarDsc* varDsc);
+
+    // Return the registers killed by the given tree node.
+    static regMaskTP getKillSetForNode(Compiler* compiler, GenTree* tree);
+
 private:
     // Determine which locals are candidates for allocation
     void            identifyCandidates();
@@ -668,7 +672,7 @@ private:
                     markAddrModeOperandsHelperMD(GenTreePtr tree, void *p);
 
     // Return the registers killed by the given tree node.
-    regMaskTP       getKillSetForNode(GenTree* tree);
+    regMaskTP getKillSetForNode(GenTree* tree);
     // Given some tree node add refpositions for all the registers this node kills
     bool            buildKillPositionsForNode(GenTree*     tree,
                                               LsraLocation currentLoc);


### PR DESCRIPTION
This removes the most obvious blocker to the use of LIR in the code generator. There may still be sneaky dependencies on the tree order invariant, but those will be difficult to discover until we're able to run tests.
