### PR TITLE
Update target-dependent lowering for LIR.

### DIFF
--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -282,6 +282,7 @@ private:
 
     LinearScan *m_lsra;
     BasicBlock *currBlock;
+    LIR::Range m_currBlockRange;
     unsigned vtableCallTemp; // local variable we use as a temp for vtable calls
 };
 

--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -1867,7 +1867,7 @@ void Lowering::LowerCast( GenTreePtr* ppTree)
 
         tree->gtFlags &= ~GTF_UNSIGNED;
         tree->gtOp.gtOp1 = tmp;
-        op1->InsertAfterSelf(tmp);
+        m_currBlockRange.InsertAfter(tmp, op1);
     }
 }
 


### PR DESCRIPTION
This requires very minimal changes: target-dependent lowering does not
do much manual editing of the IR. Most IR updates that take place during
lowering are rooted in MakeSrcContained, which will be changed as part
of target-independent lowering.
