### PR TITLE
Implement most of lowering over LIR.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1362,6 +1362,7 @@ class   Compiler
     friend class CodeGen;
     friend class LclVarDsc;
     friend class TempDsc;
+    friend class LIR;
 
 #ifndef _TARGET_64BIT_
     friend class DecomposeLongs;

--- a/src/jit/decomposelongs.h
+++ b/src/jit/decomposelongs.h
@@ -55,7 +55,7 @@ private:
     // Data
     Compiler* m_compiler;
     BasicBlock* m_block;
-    LIR::Range m_range;
+    LIR::Range m_blockRange;
 };
 
 #endif // _DECOMPOSELONGS_H_

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -18316,7 +18316,7 @@ GenTreePtr Compiler::fgGetFirstNode(GenTreePtr tree)
     GenTreePtr child = tree;
     while (child->NumChildren() > 0)
     {
-        if (child->OperIsBinary() && ((child->gtFlags & GTF_REVERSE_OPS) != 0))
+        if (child->OperIsBinary() && child->IsReverseOp())
         {
             child = child->GetChild(1);
         }

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -7308,13 +7308,13 @@ DONE:
 // gtReplaceTree: Replace a tree with a new tree.
 //
 // Arguments:
-//    stmt            - The top-level root stmt of the tree bing replaced.
+//    stmt            - The top-level root stmt of the tree being replaced.
 //                      Must not be null.
 //    tree            - The tree being replaced. Must not be null.
 //    replacementTree - The replacement tree. Must not be null.
 //
 // Return Value:
-//    Return the tree node actually replaces the old tree.
+//    The tree node that replaces the old tree.
 //
 // Assumptions:
 //    The sequencing of the stmt has been done.

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -349,7 +349,7 @@ struct GenTree
 
 #endif // FEATURE_ANYCSE
 
-    unsigned char     gtLIRFlags; // Used for nodes that are in LIR.
+    unsigned char     gtLIRFlags; // Used for nodes that are in LIR. See LIR::Flags in lir.h for the various flags.
 
 #if ASSERTION_PROP
     unsigned short     gtAssertionNum;  // 0 or Assertion table index

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -349,6 +349,8 @@ struct GenTree
 
 #endif // FEATURE_ANYCSE
 
+    unsigned char     gtLIRFlags; // Used for nodes that are in LIR.
+
 #if ASSERTION_PROP
     unsigned short     gtAssertionNum;  // 0 or Assertion table index
                                         // valid only for non-GT_STMT nodes

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -526,14 +526,10 @@ void LIR::Range::InsertAfter(GenTree* node, GenTree* insertionPoint)
 //    insertionPoint - The node before which `range` will be inserted.
 //                     Must be part of `this` range.
 //
-void LIR::Range::InsertBefore(Range& range, GenTree* insertionPoint)
+void LIR::Range::InsertBefore(const Range& range, GenTree* insertionPoint)
 {
-    // Is there anything to insert?
-    if (range.IsEmpty())
-        return;
-
-    assert(range.Begin()->gtPrev == nullptr);
-    assert(range.End()->gtNext == nullptr);
+    assert(!range.IsEmpty());
+    assert(!range.IsSubRange());
 
     if (insertionPoint == nullptr)
     {
@@ -571,14 +567,10 @@ void LIR::Range::InsertBefore(Range& range, GenTree* insertionPoint)
 //    insertionPoint - The node after which `range` will be inserted.
 //                     Must be part of `this` range.
 //
-void LIR::Range::InsertAfter(Range& range, GenTree* insertionPoint)
+void LIR::Range::InsertAfter(const Range& range, GenTree* insertionPoint)
 {
-    // Is there anything to insert?
-    if (range.IsEmpty())
-        return;
-
-    assert(range.Begin()->gtPrev == nullptr);
-    assert(range.End()->gtNext == nullptr);
+    assert(!range.IsEmpty());
+    assert(!range.IsSubRange());
 
     if (insertionPoint == nullptr)
     {

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -714,7 +714,7 @@ bool LIR::Range::TryGetUse(GenTree* node, Use* use)
     // Don't bother looking for uses of nodes that are not values.
     if (node->IsValue())
     {
-        for (GenTree* n : LIR::AsRange(node->gtNext, End()))
+        for (GenTree* n : LIR::AsRange(node->gtNext, EndExclusive()))
         {
             GenTree** edge;
             if (n->TryGetUse(node, &edge))

--- a/src/jit/lir.h
+++ b/src/jit/lir.h
@@ -114,6 +114,7 @@ public:
 
         GenTree* Begin() const;
         GenTree* End() const;
+        GenTree* EndExclusive() const;
 
         Iterator begin() const;
         Iterator end() const;
@@ -126,6 +127,10 @@ public:
 
         void InsertBefore(GenTree* node, GenTree* insertionPoint);
         void InsertAfter(GenTree* node, GenTree* insertionPoint);
+
+        void InsertBefore(Range& range, GenTree* insertionPoint);
+        void InsertAfter(Range& range, GenTree* insertionPoint);
+
         void Remove(GenTree* node);
 
         bool TryGetUse(GenTree* node, Use* use);
@@ -188,6 +193,24 @@ public:
     static Range AsRange(TContainer* container)
     {
         return Range(container->FirstLIRNodeSlot(), container->LastLIRNodeSlot());
+    }
+
+    //------------------------------------------------------------------------
+    // LIR::SetTreeSeq: Given a newly created, unsequenced HIR tree, sequence
+    // the tree (set gtNext/gtPrev pointers), and return a Range representing
+    // the list of nodes. It is expected this will later be spliced into the
+    // LIR graph afterwards.
+    //
+    // Arguments:
+    //    compiler - The Compiler context.
+    //    tree - The tree to sequence.
+    //
+    // Return Value: The newly constructed range.
+    //
+    static Range SetTreeSeq(Compiler* compiler, GenTree* tree)
+    {
+        compiler->fgSetTreeSeq(tree);
+        return AsRange(compiler->fgTreeSeqBeg, tree);
     }
 };
 

--- a/src/jit/lir.h
+++ b/src/jit/lir.h
@@ -25,7 +25,9 @@ public:
         enum : unsigned char
         {
             None = 0x00,
-            Mark = 0x01,
+            Mark = 0x01, // An aribtrary "mark" bit that can be used in place of
+                         // a more expensive data structure when processing a set
+                         // of LIR nodes. See for example `LIR::GetTreeRange`.
         };
     };
 
@@ -74,7 +76,10 @@ public:
     private:
         GenTree** m_firstNodeSlot;
         GenTree** m_lastNodeSlot;
-        bool m_isSimpleRange;
+        bool m_isSimpleRange;      // A simple range provides its own storage: instead of holding
+                                   // pointers to the first and last node tracked by some other
+                                   // container, `m_firstNodeSlot` and `m_lastNodeSlot` hold pointers
+                                   // to the first and last node in the range, respectively.
 
         Range(GenTree** firstNodeSlot, GenTree** lastNodeSlot);
         Range(GenTree* firstNode, GenTree* lastNode);

--- a/src/jit/lir.h
+++ b/src/jit/lir.h
@@ -128,8 +128,8 @@ public:
         void InsertBefore(GenTree* node, GenTree* insertionPoint);
         void InsertAfter(GenTree* node, GenTree* insertionPoint);
 
-        void InsertBefore(Range& range, GenTree* insertionPoint);
-        void InsertAfter(Range& range, GenTree* insertionPoint);
+        void InsertBefore(const Range& range, GenTree* insertionPoint);
+        void InsertAfter(const Range& range, GenTree* insertionPoint);
 
         void Remove(GenTree* node);
 

--- a/src/jit/lir.h
+++ b/src/jit/lir.h
@@ -41,7 +41,6 @@ public:
         GenTree** m_edge;
         GenTree* m_user;
 
-
     public:
         Use();
         Use(const Use& other);
@@ -75,8 +74,10 @@ public:
     private:
         GenTree** m_firstNodeSlot;
         GenTree** m_lastNodeSlot;
+        bool m_isSimpleRange;
 
         Range(GenTree** firstNodeSlot, GenTree** lastNodeSlot);
+        Range(GenTree* firstNode, GenTree* lastNode);
 
         GenTree*& FirstNode() const;
         GenTree*& LastNode() const;
@@ -159,23 +160,6 @@ public:
         bool ContainsNode(GenTree* node) const;
         bool CheckLIR(Compiler* compiler) const;
 #endif
-    };
-
-private:
-    //------------------------------------------------------------------------
-    // LIR::SimpleRange: Provides storage for a simple range defined only by
-    //                   a start and end node. Can be used in order to
-    //                   incrementally build up a range of IR to be inserted
-    //                   into another range.
-    //
-    class SimpleRange final : public Range
-    {
-    private:
-        GenTree* m_firstNode;
-        GenTree* m_lastNode;
-
-    public:
-        SimpleRange(GenTree* firstNode, GenTree* lastNode);
     };
 
 public:

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1247,7 +1247,7 @@ void Lowering::LowerCall(GenTree* node)
                     insertionPoint = m_blockRange.GetTreeRange(call->gtCallAddr, &isClosed).Begin();
                 }
 
-                (assert(isClosed), (void)isClosed);
+                assert(isClosed);
             }
         }
 
@@ -1737,7 +1737,7 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree *callTarget
 
         bool isClosed;
         callTargetRange = m_blockRange.GetTreeRange(call->gtCallAddr, &isClosed);
-        (assert(isClosed), (void)isClosed);
+        assert(isClosed);
 
         m_blockRange.Remove(callTargetRange);
     }
@@ -1774,7 +1774,7 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree *callTarget
 
     bool isClosed;
     LIR::Range secondArgRange = m_blockRange.GetTreeRange(secondArg, &isClosed);
-    (assert(isClosed), (void)isClosed);
+    assert(isClosed);
 
     m_blockRange.Remove(secondArgRange);
 
@@ -1802,7 +1802,7 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree *callTarget
 
     bool isClosed;
     LIR::Range secondArgRange = m_blockRange.GetTreeRange(arg0, &isClosed);
-    (assert(isClosed), (void)isClosed);
+    assert(isClosed);
     
     argEntry->node->gtOp.gtOp1 = callTarget;
 

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -296,6 +296,8 @@ void Lowering::LowerSwitch(GenTree* node)
 
     assert(node->gtOper == GT_SWITCH);
 
+    NYI("switch lowering in LIR");
+
     // The first step is to build the default case conditional construct that is
     // shared between both kinds of expansion of the switch node.
 

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -55,6 +55,7 @@ private:
     static Compiler::fgWalkResult TreeInfoInitHelper(GenTreePtr* ppTree, Compiler::fgWalkData* data);
     
     // Member Functions
+    void LowerBlock(BasicBlock* block);
     void LowerNode(GenTreePtr* tree, Compiler::fgWalkData* data);
     GenTreeStmt* LowerMorphAndSeqTree(GenTree *tree);
     void CheckVSQuirkStackPaddingNeeded(GenTreeCall* call);
@@ -223,11 +224,11 @@ private:
     void DumpNodeInfoMap();
 
     // Per tree node member functions
-    void LowerInd(GenTreePtr* ppTree);
+    void LowerInd(GenTree* node);
     void LowerAddrMode(GenTreePtr* ppTree, GenTree* before, Compiler::fgWalkData* data, bool isIndir);
-    void LowerAdd(GenTreePtr* ppTree, Compiler::fgWalkData* data);
-    void LowerUnsignedDivOrMod(GenTree* tree);
-    void LowerSignedDivOrMod(GenTreePtr* ppTree, Compiler::fgWalkData* data);
+    void LowerAdd(GenTree* node);
+    void LowerUnsignedDivOrMod(GenTree* node);
+    void LowerSignedDivOrMod(GenTree* node);
 
     // Remove the nodes that are no longer used after an addressing mode is constructed under a GT_IND
     void LowerIndCleanupHelper(GenTreeAddrMode* addrMode, GenTreePtr tree);
@@ -256,7 +257,7 @@ public:
 private:
     static bool NodesAreEquivalentLeaves       (GenTreePtr candidate, GenTreePtr storeInd);
 
-    GenTreePtr  CreateLocalTempAsg      (GenTreePtr rhs, unsigned refCount, GenTreePtr *ppLclVar = nullptr);
+    GenTreePtr  CreateLocalTempAsg      (GenTreePtr rhs);
     GenTreeStmt* CreateTemporary        (GenTree** ppTree);
     bool AreSourcesPossiblyModified     (GenTree* use, GenTree* src1, GenTree *src2);
     void ReplaceNode                    (GenTree** ppTreeLocation,
@@ -280,10 +281,9 @@ private:
     // Checks for memory conflicts in the instructions between childNode and parentNode, and returns true if childNode can be contained.
     bool IsSafeToContainMem(GenTree* parentNode, GenTree* childNode);
 
-    LinearScan *m_lsra;
-    BasicBlock *currBlock;
-    LIR::Range m_currBlockRange;
+    LinearScan* m_lsra;
     unsigned vtableCallTemp; // local variable we use as a temp for vtable calls
+    LIR::Range m_blockRange;    // The range of nodes in the current block.
 };
 
 #endif // _LOWER_H_

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -76,6 +76,7 @@ private:
     GenTree* LowerVirtualVtableCall   (GenTreeCall* call);
     GenTree* LowerVirtualStubCall     (GenTreeCall* call);
     void     LowerArgsForCall         (GenTreeCall* call);
+    void     ReplaceArgWithPutArgOrCopy(GenTreePtr* ppChild, GenTreePtr newNode);
     GenTree* NewPutArg                (GenTreeCall* call, GenTreePtr arg, fgArgTabEntryPtr info, var_types type);
     void     LowerArg                 (GenTreeCall* call, GenTreePtr *ppTree);
     void     InsertPInvokeCallProlog  (GenTreeCall* call);
@@ -88,25 +89,6 @@ private:
     GenTree *CreateFrameLinkUpdate(FrameLinkAction);
     GenTree *AddrGen(ssize_t addr, regNumber reg = REG_NA);
     GenTree *AddrGen(void *addr, regNumber reg = REG_NA);
-
-    // return concatenation of two trees, which currently uses a comma and really should not
-    // because we're not supposed to have commas in codegen
-    GenTree *Concat(GenTree *first, GenTree *second) 
-    { 
-        // if any is null, it must be the first
-        if (first == nullptr)
-        {
-            return second;
-        }
-        else if (second == nullptr)
-        {
-            return first;
-        }
-        else
-        {
-            return comp->gtNewOperNode(GT_COMMA, TYP_I_IMPL, first, second); 
-        }
-    }
 
     GenTree* Ind(GenTree* tree)
     {
@@ -220,23 +202,24 @@ private:
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
     void TreeNodeInfoInitLclHeap(GenTree* tree);
 
-    void SpliceInUnary(GenTreePtr parent, GenTreePtr* ppChild, GenTreePtr newNode);
     void DumpNodeInfoMap();
 
     // Per tree node member functions
-    void LowerInd(GenTree* node);
-    void LowerAddrMode(GenTreePtr* ppTree, GenTree* before, Compiler::fgWalkData* data, bool isIndir);
+    void LowerStoreInd(GenTree* node);
     void LowerAdd(GenTree* node);
     void LowerUnsignedDivOrMod(GenTree* node);
     void LowerSignedDivOrMod(GenTree* node);
 
-    // Remove the nodes that are no longer used after an addressing mode is constructed under a GT_IND
-    void LowerIndCleanupHelper(GenTreeAddrMode* addrMode, GenTreePtr tree);
-    void LowerSwitch(GenTree* node);
-    void LowerCast(GenTreePtr* ppTree);
-    void LowerCntBlockOp(GenTreePtr* ppTree);
+    void TryCreateAddrMode(LIR::Use& use, bool isIndir);
+    void AddrModeCleanupHelper(GenTreeAddrMode* addrMode, GenTree* node);
 
+    void LowerSwitch(GenTree* node);
+    void LowerCast(GenTree* node);
+
+#if defined(_TARGET_XARCH_)
     void SetMulOpCounts(GenTreePtr tree);
+#endif // defined(_TARGET_XARCH_)
+
     void LowerCmp(GenTreePtr tree);
 
 #if !CPU_LOAD_STORE_ARCH
@@ -247,7 +230,7 @@ private:
     void LowerStoreLoc(GenTreeLclVarCommon* tree);
     void SetIndirAddrOpCounts(GenTree *indirTree);
     void LowerGCWriteBarrier(GenTree *tree);
-    void LowerArrElem(GenTree **ppTree, Compiler::fgWalkData* data);
+    void LowerArrElem(GenTree* node);
     void LowerRotate(GenTree *tree);
 
     // Utility functions
@@ -257,15 +240,7 @@ public:
 private:
     static bool NodesAreEquivalentLeaves       (GenTreePtr candidate, GenTreePtr storeInd);
 
-    GenTreePtr  CreateLocalTempAsg      (GenTreePtr rhs);
-    GenTreeStmt* CreateTemporary        (GenTree** ppTree);
-    bool AreSourcesPossiblyModified     (GenTree* use, GenTree* src1, GenTree *src2);
-    void ReplaceNode                    (GenTree** ppTreeLocation,
-                                         GenTree* replacementNode,
-                                         GenTree* stmt,
-                                         BasicBlock* block);
-
-    void UnlinkNode                     (GenTree** ppParentLink, GenTree* stmt, BasicBlock* block);
+    bool AreSourcesPossiblyModified     (GenTree* addr, GenTree* base, GenTree *index);
 
     // return true if 'childNode' is an immediate that can be contained 
     //  by the 'parentNode' (i.e. folded into an instruction)
@@ -283,6 +258,7 @@ private:
 
     LinearScan* m_lsra;
     unsigned vtableCallTemp; // local variable we use as a temp for vtable calls
+    BasicBlock* m_block;
     LIR::Range m_blockRange;    // The range of nodes in the current block.
 };
 

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -56,8 +56,7 @@ private:
     
     // Member Functions
     void LowerBlock(BasicBlock* block);
-    void LowerNode(GenTreePtr* tree, Compiler::fgWalkData* data);
-    GenTreeStmt* LowerMorphAndSeqTree(GenTree *tree);
+    void LowerNode(GenTree* node);
     void CheckVSQuirkStackPaddingNeeded(GenTreeCall* call);
 
     // ------------------------------
@@ -210,7 +209,7 @@ private:
     void LowerUnsignedDivOrMod(GenTree* node);
     void LowerSignedDivOrMod(GenTree* node);
 
-    void TryCreateAddrMode(LIR::Use& use, bool isIndir);
+    void TryCreateAddrMode(LIR::Use&& use, bool isIndir);
     void AddrModeCleanupHelper(GenTreeAddrMode* addrMode, GenTree* node);
 
     void LowerSwitch(GenTree* node);

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -232,7 +232,7 @@ private:
 
     // Remove the nodes that are no longer used after an addressing mode is constructed under a GT_IND
     void LowerIndCleanupHelper(GenTreeAddrMode* addrMode, GenTreePtr tree);
-    void LowerSwitch(GenTreePtr* ppTree);
+    void LowerSwitch(GenTree* node);
     void LowerCast(GenTreePtr* ppTree);
     void LowerCntBlockOp(GenTreePtr* ppTree);
 

--- a/src/jit/lowerarm.cpp
+++ b/src/jit/lowerarm.cpp
@@ -32,12 +32,9 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include "lsra.h"
 
 /* Lowering of GT_CAST nodes */
-void Lowering::LowerCast(GenTreePtr *ppTree) { }
-
-
-void Lowering::LowerCntBlockOp(GenTreePtr *ppTree)
+void Lowering::LowerCast(GenTree* tree)
 {
-    NYI_ARM("ARM Lowering for BlockOp");
+    MYI_ARM("ARM Lowering for cast");
 }
 
 void Lowering::LowerRotate(GenTreePtr tree)

--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -1867,7 +1867,7 @@ void Lowering::LowerCast( GenTreePtr* ppTree)
 
         tree->gtFlags &= ~GTF_UNSIGNED;
         tree->gtOp.gtOp1 = tmp;
-        m_currBlockRange.InsertAfter(tmp, op1);
+        m_blockRange.InsertAfter(tmp, op1);
     }
 }
 

--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -1827,9 +1827,8 @@ void Lowering::LowerCmp(GenTreePtr tree)
  * i) GT_CAST(float/double, int type with overflow detection) 
  *
  */
-void Lowering::LowerCast( GenTreePtr* ppTree) 
+void Lowering::LowerCast(GenTree* tree) 
 {
-    GenTreePtr  tree = *ppTree;
     assert(tree->OperGet() == GT_CAST);
 
     GenTreePtr  op1 = tree->gtOp.gtOp1;

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -3259,9 +3259,8 @@ void Lowering::LowerCmp(GenTreePtr tree)
  * system.windows.forms, scimark, fractals, bio mums). If we ever find evidence that
  * doing this optimization is a win, should consider generating in-lined code.
  */
-void Lowering::LowerCast( GenTreePtr* ppTree) 
+void Lowering::LowerCast(GenTree* tree)
 {
-    GenTreePtr  tree    = *ppTree;
     assert(tree->OperGet() == GT_CAST);
 
     GenTreePtr  op1     = tree->gtOp.gtOp1;

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -3175,7 +3175,7 @@ void Lowering::LowerCmp(GenTreePtr tree)
                             }
                         }
 
-                        m_currBlockRange.Remove(removeTreeNode);
+                        m_blockRange.Remove(removeTreeNode);
 #ifdef DEBUG
                         if (comp->verbose)
                         {
@@ -3320,7 +3320,7 @@ void Lowering::LowerCast( GenTreePtr* ppTree)
 
         tree->gtFlags &= ~GTF_UNSIGNED;
         tree->gtOp.gtOp1 = tmp;
-        m_currBlockRange.InsertAfter(tmp, op1);
+        m_blockRange.InsertAfter(tmp, op1);
     }
 }
 
@@ -3351,7 +3351,7 @@ bool Lowering::IsBinOpInRMWStoreInd(GenTreePtr tree)
     }
 
     LIR::Use use;
-    if (!m_currBlockRange.TryGetUse(tree, &use) || use.User()->OperGet() != GT_STOREIND || use.User()->gtGetOp2() != tree)
+    if (!m_blockRange.TryGetUse(tree, &use) || use.User()->OperGet() != GT_STOREIND || use.User()->gtGetOp2() != tree)
     {
         return false;
     }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -17102,8 +17102,6 @@ void                Compiler::fgMarkAddressExposedLocals()
 bool Compiler::fgNodesMayInterfere(GenTree* write, GenTree* read)
 {
     LclVarDsc* srcVar = nullptr;
-    bool srcAliased = false;
-    bool dstAliased = false;
 
     bool readIsIndir  = read->OperIsIndir()  || read->OperIsImplicitIndir();
     bool writeIsIndir = write->OperIsIndir() || write->OperIsImplicitIndir();

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -1317,7 +1317,8 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, ArrayStack<G
 #endif // FEATURE_SIMD
 
     default:
-        // Nothing to do for most nodes.
+        // Ensure that the LIR flags are clear.
+        node->gtLIRFlags = LIR::Flags::None;
         break;
     }
 


### PR DESCRIPTION
As discussed, switch lowering is NYI'd and I took some shortcuts related to `fgGetFirstNode`. The latter can be found by grepping for `assert(isClosed)` in lower.cpp.
