### PR TITLE
Fix a few bugs/diffs in the LIR backend.

### DIFF
--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -528,9 +528,10 @@ GenTree* LIR::Range::FirstNonPhiOrCatchArgNode() const
 
     for (GenTree* node = FirstNonPhiNode(), *end = End(); node != end; node = node->gtNext)
     {
-        if ((node->OperGet() == GT_STORE_LCL_VAR) && (node->gtOp.gtOp1->OperGet() == GT_CATCH_ARG))
+        if ((node->OperGet() != GT_CATCH_ARG) &&
+            ((node->OperGet() != GT_STORE_LCL_VAR) || (node->gtOp.gtOp1->OperGet() != GT_CATCH_ARG)))
         {
-            return node->gtNext;
+            return node;
         }
     }
 
@@ -1090,6 +1091,8 @@ bool LIR::Range::CheckLIR(Compiler* compiler, bool checkUnusedValues) const
     {
         // Verify that the node is allowed in LIR.
         assert(node->IsLIR());
+
+        // TODO: validate catch arg stores
 
         // Check that all phi nodes (if any) occur at the start of the range.
         if ((node->OperGet() == GT_PHI_ARG) || (node->OperGet() == GT_PHI) || node->IsPhiDefn())

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -506,15 +506,26 @@ GenTree* LIR::Range::FirstNonPhiNode() const
 {
     assert(IsValid());
 
-    for (GenTree* node : *this)
+    GenTree* node, *end;
+    for (node = Begin(), end = End(); node != end; node = node->gtNext)
     {
-        if ((node->OperGet() != GT_PHI_ARG) && (node->OperGet() != GT_PHI) && !node->IsPhiDefn())
+        if (node->OperGet() == GT_PHI_ARG)
         {
-            return node;
+            continue;
         }
+        else if (node->OperGet() == GT_PHI)
+        {
+            continue;
+        }
+        else if (node->IsPhiDefn())
+        {
+            continue;
+        }
+
+        break;
     }
 
-    return End();
+    return node;
 }
 
 //------------------------------------------------------------------------
@@ -526,16 +537,22 @@ GenTree* LIR::Range::FirstNonPhiOrCatchArgNode() const
 {
     assert(IsValid());
 
-    for (GenTree* node = FirstNonPhiNode(), *end = End(); node != end; node = node->gtNext)
+    GenTree* node, *end;
+    for (node = FirstNonPhiNode(), end = End(); node != end; node = node->gtNext)
     {
-        if ((node->OperGet() != GT_CATCH_ARG) &&
-            ((node->OperGet() != GT_STORE_LCL_VAR) || (node->gtOp.gtOp1->OperGet() != GT_CATCH_ARG)))
+        if (node->OperGet() == GT_CATCH_ARG)
         {
-            return node;
+            continue;
         }
+        else if ((node->OperGet() == GT_STORE_LCL_VAR) && (node->gtGetOp1()->OperGet() == GT_CATCH_ARG))
+        {
+            continue;
+        }
+
+        break;
     }
 
-    return End();
+    return node;
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2330,8 +2330,7 @@ void Lowering::InsertPInvokeMethodProlog()
     }
 
     comp->fgMorphTree(store);
-    firstBlockRange.InsertAfter(LIR::SeqTree(comp, store), insertionPoint);
-    insertionPoint = store;
+    firstBlockRange.InsertBefore(LIR::SeqTree(comp, store), insertionPoint);
 
     DISPTREE(store);
 
@@ -2345,8 +2344,7 @@ void Lowering::InsertPInvokeMethodProlog()
                                                     callFrameInfo.offsetOfCallSiteSP);
     storeSP->gtOp1 = PhysReg(REG_SPBASE);
 
-    firstBlockRange.InsertAfter(LIR::SeqTree(comp, storeSP), insertionPoint);
-    insertionPoint = storeSP;
+    firstBlockRange.InsertBefore(LIR::SeqTree(comp, storeSP), insertionPoint);
 
     DISPTREE(storeSP);
 
@@ -2360,8 +2358,7 @@ void Lowering::InsertPInvokeMethodProlog()
                                                     callFrameInfo.offsetOfCalleeSavedFP);
     storeFP->gtOp1 = PhysReg(REG_FPBASE);
 
-    firstBlockRange.InsertAfter(LIR::SeqTree(comp, storeFP), insertionPoint);
-    insertionPoint = storeFP;
+    firstBlockRange.InsertBefore(LIR::SeqTree(comp, storeFP), insertionPoint);
 
     DISPTREE(storeFP);
 
@@ -2372,7 +2369,7 @@ void Lowering::InsertPInvokeMethodProlog()
         // Push a frame - if we are NOT in an IL stub, this is done right before the call
         // The init routine sets InlinedCallFrame's m_pNext, so we just set the thead's top-of-stack
         GenTree* frameUpd = CreateFrameLinkUpdate(PushFrame);
-        firstBlockRange.InsertAfter(LIR::SeqTree(comp, frameUpd), insertionPoint);
+        firstBlockRange.InsertBefore(LIR::SeqTree(comp, frameUpd), insertionPoint);
         DISPTREE(frameUpd);
     }
 }


### PR DESCRIPTION
- Clear the GTF_VAR_USEDEF bit as part of rationalization. This bit is
  not used in the backend and causes liveness to be unnecessarily
  pessimistic when calculating use/def sets.
- Fix LIR::Range::FirstNonPhiOrCatchArgNode, which was just broken.
- Simplify the insertion pattern used by InsertPInvokeMethodProlog.

With these changes I am seeing the following diffs when jitting a debug
build of Hello World:
- LIR rationalization more aggressively drops side-effect-free
  operands to commas. This results in an extra nop in the baseline
  codegen. These diffs can probably be prevented with a close reading of
  the current comma processing.
- LIR liveness more aggressively removes dead stores. The current backend
  gives up on dead stores that involve embedded statements. These diffs
  are unlikely to be preventable: preventing them would require the
  ability to detect whether or not a dead store would have involved an
  embedded statement, and adding this capacity is likely to require
  substantial effort for very little benefit.
