### PR TITLE
Fix ref count updates over LIR.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2481,6 +2481,7 @@ public :
 
     static fgWalkPreFn  lvaDecRefCntsCB;
     void                lvaDecRefCnts           (GenTreePtr tree);
+    void                lvaDecRefCnts           (BasicBlock* basicBlock, GenTreePtr tree);
     void                lvaRecursiveDecRefCounts(GenTreePtr tree);
     void                lvaRecursiveIncRefCounts(GenTreePtr tree);
 

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -2245,6 +2245,15 @@ void Compiler::lvaRecursiveIncRefCounts(GenTreePtr tree)
  */
 void               Compiler::lvaDecRefCnts(GenTreePtr tree)
 {
+    assert(compCurBB != nullptr);
+    lvaDecRefCnts(compCurBB, tree);
+}
+
+void               Compiler::lvaDecRefCnts(BasicBlock* block, GenTreePtr tree)
+{
+    assert(block != nullptr);
+    assert(tree != nullptr);
+
     unsigned        lclNum;
     LclVarDsc   *   varDsc;
 
@@ -2264,8 +2273,8 @@ void               Compiler::lvaDecRefCnts(GenTreePtr tree)
 
             /* Decrement the reference counts twice */
 
-            varDsc->decRefCnts(compCurBB->getBBWeight(this), this);  
-            varDsc->decRefCnts(compCurBB->getBBWeight(this), this);
+            varDsc->decRefCnts(block->getBBWeight(this), this);  
+            varDsc->decRefCnts(block->getBBWeight(this), this);
         }
     }
     else
@@ -2283,7 +2292,7 @@ void               Compiler::lvaDecRefCnts(GenTreePtr tree)
 
         /* Decrement its lvRefCnt and lvRefCntWtd */
 
-        varDsc->decRefCnts(compCurBB->getBBWeight(this), this);
+        varDsc->decRefCnts(block->getBBWeight(this), this);
     }
 }
 

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -1232,3 +1232,15 @@ LIR::Range LIR::SeqTree(Compiler* compiler, GenTree* tree)
     compiler->gtSetEvalOrder(tree);
     return AsRange(compiler->fgSetTreeSeq(tree, nullptr, true), tree);
 }
+
+// TODO(pdg): this should probably just be folded into LIR::Range::Remove(const Range& range);
+void LIR::DecRefCnts(Compiler* compiler, BasicBlock* block, const Range& range)
+{
+    for (GenTree* node : range)
+    {
+        if (((node->OperGet() == GT_CALL) && ((node->gtFlags & GTF_CALL_UNMANAGED) != 0)) || node->OperIsLocal())
+        {
+            compiler->lvaDecRefCnts(block, node);
+        }
+    }
+}

--- a/src/jit/lir.h
+++ b/src/jit/lir.h
@@ -237,6 +237,7 @@ public:
     static Range EmptyRange();
     static Range AsRange(GenTree* firstNode, GenTree* lastNode);
     static Range SeqTree(Compiler* compiler, GenTree* tree);
+    static void DecRefCnts(Compiler* compiler, BasicBlock* block, const Range& range);
 
     //------------------------------------------------------------------------
     // LIR::AsRange: Constructs and returns an LIR::Range value given a value

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -2386,9 +2386,19 @@ bool Compiler::fgTryRemoveDeadLIRStore(LIR::Range& blockRange, GenTree* node, Ge
     }
 
     // Okay, the operands to the store form a contiguous range that has no side effects. Remove the
-    // range containing the operands and then remove the store.
+    // range containing the operands and then remove the store. Once these have been removed, walk
+    // them and decrement local var ref counts appropriately.
     blockRange.Remove(operandsRange);
     blockRange.Remove(store);
+
+    // TODO(pdg): this scan should really be folded into LIR::Range::Remove().
+    LIR::DecRefCnts(this, compCurBB, operandsRange);
+
+    if (store->IsLocal())
+    {
+        lvaDecRefCnts(store);
+    }
+
     return true;
 }
 

--- a/src/jit/rationalize.h
+++ b/src/jit/rationalize.h
@@ -8,6 +8,7 @@
 class Rationalizer : public Phase
 {
 private:
+    BasicBlock* m_block;
     LIR::Range m_range;
     GenTreeStmt* m_statement;
 


### PR DESCRIPTION
Liveness and rationalize were not updating local var ref counts when
removing code. This was causing some diffs in frame sizes and prolog
code for LIR. With these changes the only diffs in "Hello, World!"
are due to more aggressive DCE in LIR rationalize and liveness.
