### PR TITLE
Fix LowerTailCallViaHelper

### DIFF
--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -1198,6 +1198,7 @@ bool LIR::Range::CheckLIR(Compiler* compiler, bool checkUnusedValues) const
 //------------------------------------------------------------------------
 // LIR::EmptyRange: Constructs and returns an empty range.
 //
+// static
 LIR::Range LIR::EmptyRange()
 {
     return Range(static_cast<GenTree*>(nullptr), static_cast<GenTree*>(nullptr));
@@ -1211,9 +1212,22 @@ LIR::Range LIR::EmptyRange()
 //    firstNode - The first node in the range. Must precede lastNode.
 //    lastNode - The last node in the range. Must follow firstNode.
 //
+// static
 LIR::Range LIR::AsRange(GenTree* firstNode, GenTree* lastNode)
 {
     return Range(firstNode, lastNode);
+}
+
+//------------------------------------------------------------------------
+// LIR::AsRange: Constructs and returns a range given a sequenced HIR tree.
+//
+// Arguments:
+//    tree - The sequenced HIR tree.
+//
+// static
+LIR::Range LIR::AsRange(Compiler* compiler, GenTree* tree)
+{
+    return Range(compiler->fgGetFirstNode(tree), tree);
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/lir.h
+++ b/src/jit/lir.h
@@ -236,6 +236,7 @@ public:
 public:
     static Range EmptyRange();
     static Range AsRange(GenTree* firstNode, GenTree* lastNode);
+    static Range AsRange(Compiler* compiler, GenTree* tree);
     static Range SeqTree(Compiler* compiler, GenTree* tree);
     static void DecRefCnts(Compiler* compiler, BasicBlock* block, const Range& range);
 

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1747,25 +1747,21 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree *callTarget
     }
 
     // Remove gtCallAddr from execution order if present.
-    LIR::Range callTargetRange;
     if (call->gtCallType == CT_INDIRECT)
     {
         assert(call->gtCallAddr != nullptr);
 
         bool isClosed;
-        callTargetRange = m_blockRange.GetTreeRange(call->gtCallAddr, &isClosed);
+        LIR::Range callAddrRange = m_blockRange.GetTreeRange(call->gtCallAddr, &isClosed);
         assert(isClosed);
 
-        m_blockRange.Remove(callTargetRange);
+        m_blockRange.Remove(callAddrRange);
     }
-    else
-    {
-        assert(call->gtCallAddr == nullptr);
-        callTargetRange = LIR::SeqTree(comp, callTarget);
-    }
+
+    // The callTarget tree needs to be sequenced.
+    LIR::Range callTargetRange = LIR::SeqTree(comp, callTarget);
 
     fgArgTabEntry* argEntry;
-
 
 #if defined(_TARGET_AMD64_)
 


### PR DESCRIPTION
Make it follow previous code sequence more carefully.

Add an LIR::Range::AsRange() constructor for sequenced HIR trees.

@pgavlin PTAL
