### PR TITLE
Fix isContained and endsWith{JmpMethod,TailCall} for LIR.

### DIFF
--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -4719,9 +4719,9 @@ inline bool         BasicBlock::endsWithJmpMethod(Compiler *comp)
 {
     if (comp->compJmpOpUsed && (bbJumpKind == BBJ_RETURN) && (bbFlags & BBF_HAS_JMP))
     {
-        GenTreePtr last = comp->fgGetLastTopLevelStmt(this);
-        assert(last != nullptr);
-        return last->gtStmt.gtStmtExpr->gtOper == GT_JMP;
+        GenTree* lastNode = IsLIR() ? bbLastNode : comp->fgGetLastTopLevelStmt(this)->gtStmt.gtStmtExpr;
+        assert(lastNode != nullptr);
+        return lastNode->OperGet() == GT_JMP;
     }
 
     return false;
@@ -4782,12 +4782,10 @@ inline bool BasicBlock::endsWithTailCall(Compiler* comp, bool fastTailCallsOnly,
 
         if (result)
         {
-            GenTreePtr last = comp->fgGetLastTopLevelStmt(this);
-            assert(last != nullptr);
-            last = last->gtStmt.gtStmtExpr;
-            if (last->OperGet() == GT_CALL)
+            GenTree* lastNode = IsLIR() ? bbLastNode : comp->fgGetLastTopLevelStmt(this)->gtStmt.gtStmtExpr;
+            if (lastNode->OperGet() == GT_CALL)
             {
-                GenTreeCall* call = last->AsCall();
+                GenTreeCall* call = lastNode->AsCall();
                 if (tailCallsConvertibleToLoopOnly)
                 {
                     result = call->IsTailCallConvertibleToLoop();

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -2848,13 +2848,19 @@ bool                Compiler::fgIsThrowHlpBlk(BasicBlock * block)
     {
         // TODO(pdg): it would be nice if there was simply a bit on the block we could check.
         LIR::Range blockRange = LIR::AsRange(block);
+        call = blockRange.EndExclusive();
+
+#ifdef DEBUG
         for (LIR::Range::ReverseIterator node = blockRange.rbegin(), end = blockRange.rend(); node != end; ++node)
         {
             if (node->OperGet() == GT_CALL)
             {
-                call = *node;
+                assert(*node == call);
+                assert(node == blockRange.rbegin());
+                break;
             }
         }
+#endif
     }
     else
     {

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -2843,7 +2843,22 @@ bool                Compiler::fgIsThrowHlpBlk(BasicBlock * block)
     if (!(block->bbFlags & BBF_INTERNAL) || block->bbJumpKind != BBJ_THROW)
         return false;
 
-    GenTreePtr  call = block->bbTreeList->gtStmt.gtStmtExpr;
+    GenTree* call = nullptr;
+    if (block->IsLIR())
+    {
+        // TODO(pdg): it would be nice if there was simply a bit on the block we could check.
+        for (GenTree* node : LIR::AsRange(block))
+        {
+            if (node->OperGet() == GT_CALL)
+            {
+                call = node;
+            }
+        }
+    }
+    else
+    {
+        call = block->bbTreeList->gtStmt.gtStmtExpr;
+    }
 
     if (!call || (call->gtOper != GT_CALL))
         return false;

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -2847,11 +2847,12 @@ bool                Compiler::fgIsThrowHlpBlk(BasicBlock * block)
     if (block->IsLIR())
     {
         // TODO(pdg): it would be nice if there was simply a bit on the block we could check.
-        for (GenTree* node : LIR::AsRange(block))
+        LIR::Range blockRange = LIR::AsRange(block);
+        for (LIR::Range::ReverseIterator node = blockRange.rbegin(), end = blockRange.rend(); node != end; ++node)
         {
             if (node->OperGet() == GT_CALL)
             {
-                call = node;
+                call = *node;
             }
         }
     }

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -14040,6 +14040,7 @@ bool GenTree::isContained() const
     case GT_LCLHEAP:
     case GT_CKFINITE:
     case GT_JMP:
+    case GT_IL_OFFSET:
 #ifdef FEATURE_SIMD
     case GT_SIMD_CHK:
 #endif // FEATURE_SIMD

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -383,7 +383,7 @@ public:
     // Insert a copy in the case where a tree node value must be moved to a different
     // register at the point of use, or it is reloaded to a different register
     // than the one it was spilled from
-    void            insertCopyOrReload(GenTreePtr tree, unsigned multiRegIdx, RefPosition* refPosition);
+    void            insertCopyOrReload(BasicBlock* block, GenTreePtr tree, unsigned multiRegIdx, RefPosition* refPosition);
 
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
     // Insert code to save and restore the upper half of a vector that lives
@@ -710,7 +710,7 @@ private:
     void            buildInternalRegisterUsesForNode(GenTree *tree, LsraLocation currentLoc,
                                                      RefPosition* defs[], int total);
 
-    void            resolveLocalRef(GenTreePtr treeNode, RefPosition * currentRefPosition);
+    void            resolveLocalRef(BasicBlock* block, GenTreePtr treeNode, RefPosition * currentRefPosition);
 
     void            insertMove(BasicBlock * block, GenTreePtr insertionPoint, unsigned lclNum,
                                regNumber inReg, regNumber outReg);

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -1379,13 +1379,14 @@ void Rationalizer::DoPhase()
 {
     DBEXEC(TRUE, SanityCheck());
 
-    comp->compCurBB = NULL;
+    comp->compCurBB = nullptr;
     comp->fgOrder = Compiler::FGOrderLinear;
 
     BasicBlock* firstBlock = comp->fgFirstBB;
 
     for (BasicBlock* block = comp->fgFirstBB; block != nullptr; block = block->bbNext)
     {
+        comp->compCurBB = block;
         m_block = block;
 
         // Establish the first and last nodes for the block. This is necessary in order for the LIR


### PR DESCRIPTION
With these fixes, I can successfully crossgen all of a debug build of S.P.CoreLib.dll on amd64 Unix and Windows.
