### PR TITLE
Diff + correctness fixes for the LIR backend.

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -13769,6 +13769,13 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
         GenTree* switchVal = switchTree->gtOp.gtOp1;
         noway_assert(genActualTypeIsIntOrI(switchVal->TypeGet()));
 
+        // If we are in LIR, remove the switch table from the block.
+        if (block->IsLIR())
+        {
+            GenTree* switchTable = switchTree->gtOp.gtOp2;
+            blockRange.Remove(switchTable);
+        }
+
         // Change the GT_SWITCH(switchVal) into GT_JTRUE(GT_EQ(switchVal==0)).
         // Also mark the node as GTF_DONT_CSE as further down JIT is not capable of handling it.
         // For example CSE could determine that the expression rooted at GT_EQ is a candidate cse and

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -13769,11 +13769,12 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
         GenTree* switchVal = switchTree->gtOp.gtOp1;
         noway_assert(genActualTypeIsIntOrI(switchVal->TypeGet()));
 
-        // If we are in LIR, remove the switch table from the block.
+        // If we are in LIR, remove the jump table from the block.
         if (block->IsLIR())
         {
-            GenTree* switchTable = switchTree->gtOp.gtOp2;
-            blockRange.Remove(switchTable);
+            GenTree* jumpTable = switchTree->gtOp.gtOp2;
+            assert(jumpTable->OperGet() == GT_JMPTABLE);
+            blockRange.Remove(jumpTable);
         }
 
         // Change the GT_SWITCH(switchVal) into GT_JTRUE(GT_EQ(switchVal==0)).

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -8280,7 +8280,7 @@ void GenTreeUseEdgeIterator::MoveToNextSIMDUseEdge()
                 break;
         }
 
-        if (m_edge != nullptr)
+        if (m_edge != nullptr && *m_edge != nullptr)
         {
             m_state++;
         }

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -314,7 +314,7 @@ LIR::Range::Range(GenTree** firstNodeSlot, GenTree** lastNodeSlot)
     assert(firstNodeSlot != lastNodeSlot);
 
     assert((FirstNode() != nullptr) == (LastNode() != nullptr));
-    assert((FirstNode() == LastNode()) || FirstNode()->Precedes(LastNode()));
+    assert((FirstNode() == LastNode()) || ContainsNode(LastNode()));
 }
 
 //------------------------------------------------------------------------
@@ -332,7 +332,7 @@ LIR::Range::Range(GenTree* firstNode, GenTree* lastNode)
     , m_isSimpleRange(true)
 {
     assert((FirstNode() != nullptr) == (LastNode() != nullptr));
-    assert((FirstNode() == LastNode()) || FirstNode()->Precedes(LastNode()));
+    assert((FirstNode() == LastNode()) || ContainsNode(LastNode()));
 }
 
 
@@ -1058,6 +1058,14 @@ LIR::Range LIR::Range::GetRangeOfOperandTrees(GenTree* root, bool* isClosed, uns
 bool LIR::Range::ContainsNode(GenTree* node) const
 {
     assert(node != nullptr);
+
+    // TODO(pdg): derive this from the # of nodes in the function as well as
+    // the debug level. Checking small functions is pretty cheap; checking
+    // large functions is not.
+    if (JitConfig.JitExpensiveDebugCheckLevel() < 2)
+    {
+        return true;
+    }
 
     for (GenTree* n : *this)
     {

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -3545,6 +3545,11 @@ GenTree* Lowering::LowerArrElem(GenTree* node)
 
     GenTreePtr leaNode = new(comp, GT_LEA) GenTreeAddrMode(arrElem->TypeGet(), leaBase, leaIndexNode, scale, offset);
     leaNode->gtFlags |= GTF_REVERSE_OPS;
+
+    // Set the costs for all of the new nodes. Depends on the new nodes all participating in the
+    // dataflow tree rooted at `leaNode`.
+    comp->gtPrepareCost(leaNode);
+
     m_blockRange.InsertBefore(leaNode, insertionPoint);
 
     LIR::Use arrElemUse;

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -611,9 +611,6 @@ void Rationalizer::RewriteCopyBlk(LIR::Use& use)
     GenTree* list = cpBlk->gtGetOp1();
     if (oper == GT_STORE_LCL_VAR)
     {
-        // get rid of the list node
-        m_range.Remove(list);
-
         newNode = simdDst;
         newNode->SetOper(oper);
 
@@ -637,6 +634,8 @@ void Rationalizer::RewriteCopyBlk(LIR::Use& use)
         storeInd->gtFlags |= (simdSrc->gtFlags & GTF_ALL_EFFECT);
         storeInd->gtOp1 = simdDst;
         storeInd->gtOp2 = simdSrc;
+
+        m_range.InsertBefore(newNode, cpBlk);
     } 
 
     use.ReplaceWith(comp, newNode);
@@ -1235,11 +1234,11 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, ArrayStack<G
 #ifdef _TARGET_XARCH_
     case GT_CLS_VAR:
         {
-            node->SetOper(GT_CLS_VAR_ADDR);
-            node->gtType = TYP_BYREF;
-
             GenTree* ind = comp->gtNewOperNode(GT_IND, node->TypeGet(), node);
             ind->CopyCosts(node);
+
+            node->SetOper(GT_CLS_VAR_ADDR);
+            node->gtType = TYP_BYREF;
 
             m_range.InsertAfter(ind, node);
             use.ReplaceWith(comp, ind);

--- a/src/jit/smallhash.h
+++ b/src/jit/smallhash.h
@@ -135,10 +135,12 @@ private:
         {
             // The home bucket is empty; use it.
             //
-            // Note that the next offset does not need to be updated: whether or not it is non-zero,
-            // it is already correct, since we're inserting at the head of the list.
+            // Note that `m_firstOffset` does not need to be updated: whether or not it is non-zero,
+            // it is already correct, since we're inserting at the head of the list. `m_nextOffset`
+            // must be 0, however, since this node should not be part of a list.
+            assert(home->m_nextOffset == 0);
+
             home->m_isFull = true;
-            home->m_firstOffset = 0;
             home->m_hash = hash;
             home->m_key = key;
             home->m_value = value;
@@ -172,6 +174,8 @@ private:
                 }
 
                 unsigned offset = (bucketIndex - precedingIndexInChain) & mask;
+                assert(offset != 0);
+
                 if (precedingIndexInChain == homeIndex)
                 {
                     buckets[precedingIndexInChain].m_firstOffset = offset;
@@ -483,7 +487,6 @@ public:
         }
 
         Bucket* bucket = &m_buckets[bucketIndex];
-        bucket->m_isFull = false;
 
         if (precedingIndexInChain != bucketIndex)
         {
@@ -510,6 +513,9 @@ public:
                 m_buckets[precedingIndexInChain].m_nextOffset = nextOffset;
             }
         }
+
+        bucket->m_isFull = false;
+        bucket->m_nextOffset = 0;
 
         m_numFullBuckets--;
 


### PR DESCRIPTION
### Fixes for diffs

The current backend happily removes dead stores with the GTF_ORDER bit
set unless the value being stored is a catch arg. The LIR implementation
was a bit more conservative, refusing to remove dead stores with any of
the GTF_ALL_EFFECT bits set. Change this to match the current
implementation.
### Correctness fixes
- Fix use edge iteration for SIMD nodes.
- Fix broken pattern recognition in SIMD lowering.
- Set the GTF_ASG flag on stores created during SIMD rationalization
  in order to keep later passes from dropping them.
- Fix SIMD copyblk lowering
- Fix GT_CLSVAR lowering for X86
- Fix removal and insertion of KVPs from/to a home bucket in HashTable.
- Remove switch tables when simplifying LIR switches.
### Misc.
- Move `ContainsNode()` asserts in `LIR::Range` under a higher debug level.
  These checks are run extremely frequently and end up costing an undue
  amount of time in debug/checked builds.
