### PR TITLE
Fixes for x86 LIR

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -3941,7 +3941,7 @@ void                Compiler::compFunctionTraceStart()
 
         for (LONG i = 0; i < newJitNestingLevel - 1; i++)
             printf("  ");
-        printf("{ Start Jitting %s\n", info.compFullName); /* } editor brace matching workaround for this printf */
+        printf("{ Start Jitting %s (MethodHash=%08x)\n", info.compFullName, info.compMethodHash()); /* } editor brace matching workaround for this printf */
     }
 #endif // DEBUG
 }

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1014,13 +1014,11 @@ void Lowering::LowerArg(GenTreeCall* call, GenTreePtr* ppArg)
 #if !defined(_TARGET_64BIT_)
     if (varTypeIsLong(type))
     {
-        // TODO(pdg): the code below uses tree order to freely reorder the lo and hi pieces of
-        // a long-type argument. This needs to be fixed.
-
         if (isReg)
         {
             NYI("Lowering of long register argument");
         }
+
         // For longs, we will create two PUTARG_STKs below the GT_LONG.
         // This is because the lo/hi values will be marked localDefUse, and we need to ensure that
         // they are pushed onto the stack as soon as they are created.
@@ -1039,6 +1037,10 @@ void Lowering::LowerArg(GenTreeCall* call, GenTreePtr* ppArg)
 
         arg->gtOp.gtOp1 = putArgLo;
         arg->gtOp.gtOp2 = putArgHi;
+
+        // TODO(pdg): the code below uses tree order to freely reorder the lo and hi pieces of
+        // a long-type argument. This needs to be fixed.
+        NYI("LIR: long arg lowering");
 
         // Now, reorder the arguments and insert the putArg in the right place.
 


### PR DESCRIPTION
With this, crossgen of x86 S.P.C.dll is as clean as the non-LIR version. There is a known
assert with checked. With debug, there are a number of crashes with JMP calls that also
occur with the legacy JIT.

There is one big caveat: I added an NYI in LowerArg for long stack arguments. This hits 450 times.
The code is:

```
// TODO(pdg): the code below uses tree order to freely reorder the lo and hi pieces of
// a long-type argument. This needs to be fixed.
NYI("LIR: long arg lowering");
```

This will be fixed next.

The changes:
1. During decomposition, make sure tree costs are set.
2. Fix bug in LIR::Range::rend() if the range is empty.
3. In CheckLIR(), make sure the forward and reverse threadings have no circularities.

Also:
a. Dump MethodHash with COMPLUS_JitFunctionTrace

@pgavlin PTAL
