### PR TITLE
Refactor some of the LIR utilities.

### DIFF
--- a/src/jit/block.cpp
+++ b/src/jit/block.cpp
@@ -262,7 +262,11 @@ void BasicBlock::dspFlags()
     if (bbFlags & BBF_LOOP_PREHEADER)       printf("LoopPH ");
     if (bbFlags & BBF_COLD)                 printf("cold ");
     if (bbFlags & BBF_PROF_WEIGHT)          printf("IBC ");
+#ifdef LEGACY_BACKEND
     if (bbFlags & BBF_FORWARD_SWITCH)       printf("fswitch ");
+#else // !LEGACY_BACKEND
+    if (bbFlags & BBF_IS_LIR)               printf("LIR ");
+#endif // LEGACY_BACKEND
     if (bbFlags & BBF_KEEP_BBJ_ALWAYS)      printf("KEEP ");
 }
 
@@ -506,13 +510,14 @@ void BasicBlock::MakeLIR(GenTree* firstNode, GenTree* lastNode)
 
     m_firstNode = firstNode;
     m_lastNode = lastNode;
-    bbIsLIR = 1;
+    bbFlags |= BBF_IS_LIR;
 }
 
 bool BasicBlock::IsLIR()
 {
-    assert((bbTreeList == nullptr) || ((bbIsLIR != 0) == !bbTreeList->IsStatement()));
-    return bbIsLIR != 0;
+    const bool isLIR = (bbFlags & BBF_IS_LIR) != 0;
+    assert((bbTreeList == nullptr) || ((isLIR) == !bbTreeList->IsStatement()));
+    return isLIR;
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -8988,7 +8988,7 @@ void                CodeGen::genFnEpilog(BasicBlock* block)
 
         /* figure out what jump we have */
 
-        GenTree* jmpNode = block->bbLastNode;
+        GenTree* jmpNode = block->lastNode();
         noway_assert(jmpNode->gtOper == GT_JMP);
 
         CORINFO_METHOD_HANDLE  methHnd    = (CORINFO_METHOD_HANDLE)jmpNode->gtVal.gtVal1;
@@ -9112,7 +9112,7 @@ void                CodeGen::genFnEpilog(BasicBlock* block)
         noway_assert(block->bbTreeList != nullptr);
 
         // figure out what jump we have
-        GenTree* jmpNode = block->bbLastNode;
+        GenTree* jmpNode = block->lastNode();
 #if !FEATURE_FASTTAILCALL
         noway_assert(jmpNode->gtOper == GT_JMP);
 #else

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -9384,7 +9384,7 @@ void                CodeGen::genFnEpilog(BasicBlock* block)
         noway_assert(block->bbTreeList);
 
         // figure out what jump we have
-        GenTree* jmpNode = LIR::AsRange(block).LastNode();
+        GenTree* jmpNode = block->lastNode();
 #if !FEATURE_FASTTAILCALL
         // x86                        
         noway_assert(jmpNode->gtOper == GT_JMP);                

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -9384,7 +9384,7 @@ void                CodeGen::genFnEpilog(BasicBlock* block)
         noway_assert(block->bbTreeList);
 
         // figure out what jump we have
-        GenTree* jmpNode = block->bbLastNode;
+        GenTree* jmpNode = LIR::AsRange(block).LastNode();
 #if !FEATURE_FASTTAILCALL
         // x86                        
         noway_assert(jmpNode->gtOper == GT_JMP);                

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -1057,12 +1057,12 @@ void                CodeGen::genCodeForBBlist()
         case BBJ_EHFILTERRET:
             {
                 // The last statement of the block must be a GT_RETFILT, which has already been generated.
-                assert(block->bbLastNode != nullptr);
-                assert(block->bbLastNode->OperGet() == GT_RETFILT);
+                assert(block->lastNode() != nullptr);
+                assert(block->lastNode()->OperGet() == GT_RETFILT);
 
                 if (block->bbJumpKind == BBJ_EHFINALLYRET)
                 {
-                    assert(block->bbLastNode->gtOp.gtOp1 == nullptr); // op1 == nullptr means endfinally
+                    assert(block->lastNode()->gtOp.gtOp1 == nullptr); // op1 == nullptr means endfinally
 
                     // Return using a pop-jmp sequence. As the "try" block calls
                     // the finally with a jmp, this leaves the x86 call-ret stack

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -638,8 +638,7 @@ void                CodeGen::genCodeForBBlist()
 #ifdef DEBUGGING_SUPPORT
         IL_OFFSETX currentILOffset = BAD_IL_OFFSET;
 #endif
-        LIR::Range blockRange = LIR::AsRange(block);
-        for (GenTree* node = blockRange.FirstNonPhiNode(), *end = blockRange.End(); node != end; node = node->gtNext)
+        for (GenTree* node : LIR::AsRange(block).NonPhiNodes())
         {
 #ifdef DEBUGGING_SUPPORT
             // Do we have a new IL offset?

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -24,6 +24,9 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 #include "jit.h"
 #include "opcode.h"
+#include "varset.h"
+#include "gentree.h"
+#include "lir.h"
 #include "block.h"
 #include "inline.h"
 #include "jiteh.h"
@@ -32,7 +35,6 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include "sm.h"
 #include "simplerhash.h"
 #include "cycletimer.h"
-#include "varset.h"
 #include "blockset.h"
 #include "jitstd.h"
 #include "arraystack.h"
@@ -58,8 +60,6 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include "emit.h"
 
 #include "simd.h"
-
-#include "lir.h"
 
 // This is only used locally in the JIT to indicate that 
 // a verification block should be inserted 
@@ -120,7 +120,6 @@ void * __cdecl operator new(size_t n, void* p, const jitstd::placement_t& syntax
 /* This is included here and not earlier as it needs the definition of "CSE"
  * which is defined in the section above */
 
-#include "gentree.h"
 
 /*****************************************************************************/
 

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -2847,8 +2847,8 @@ bool                Compiler::fgIsThrowHlpBlk(BasicBlock * block)
     if (block->IsLIR())
     {
         // TODO(pdg): it would be nice if there was simply a bit on the block we could check.
-        LIR::Range blockRange = LIR::AsRange(block);
-        call = blockRange.EndExclusive();
+        LIR::Range& blockRange = LIR::AsRange(block);
+        call = blockRange.LastNode();
 
 #ifdef DEBUG
         for (LIR::Range::ReverseIterator node = blockRange.rbegin(), end = blockRange.rend(); node != end; ++node)
@@ -4741,7 +4741,7 @@ inline bool         BasicBlock::endsWithJmpMethod(Compiler *comp)
 {
     if (comp->compJmpOpUsed && (bbJumpKind == BBJ_RETURN) && (bbFlags & BBF_HAS_JMP))
     {
-        GenTree* lastNode = IsLIR() ? bbLastNode : comp->fgGetLastTopLevelStmt(this)->gtStmt.gtStmtExpr;
+        GenTree* lastNode = this->lastNode();
         assert(lastNode != nullptr);
         return lastNode->OperGet() == GT_JMP;
     }
@@ -4804,7 +4804,7 @@ inline bool BasicBlock::endsWithTailCall(Compiler* comp, bool fastTailCallsOnly,
 
         if (result)
         {
-            GenTree* lastNode = IsLIR() ? bbLastNode : comp->fgGetLastTopLevelStmt(this)->gtStmt.gtStmtExpr;
+            GenTree* lastNode = this->lastNode();
             if (lastNode->OperGet() == GT_CALL)
             {
                 GenTreeCall* call = lastNode->AsCall();

--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -70,22 +70,21 @@ void DecomposeLongs::DecomposeBlock(BasicBlock* block)
     assert(block->isEmpty() || block->IsLIR());
 
     m_block = block;
-    m_blockRange = LIR::AsRange(block);
+    BlockRange() = LIR::AsRange(block);
 
-    GenTree* node = m_blockRange.FirstNonPhiNode();
-    GenTree* end = m_blockRange.End();
-    while (node != end)
+    GenTree* node = BlockRange().FirstNonPhiNode();
+    while (node != nullptr)
     {
         LIR::Use use;
-        if (!m_blockRange.TryGetUse(node, &use))
+        if (!BlockRange().TryGetUse(node, &use))
         {
-            use = LIR::Use::GetDummyUse(m_blockRange, node);
+            use = LIR::Use::GetDummyUse(BlockRange(), node);
         }
 
         node = DecomposeNode(use);
     }
 
-    assert(m_blockRange.CheckLIR(m_compiler));
+    assert(BlockRange().CheckLIR(m_compiler));
 }
 
 
@@ -285,16 +284,16 @@ GenTree* DecomposeLongs::FinalizeDecomposition(LIR::Use& use, GenTree* loResult,
     assert(use.IsInitialized());
     assert(loResult != nullptr);
     assert(hiResult != nullptr);
-    assert(m_blockRange.ContainsNode(loResult));
-    assert(m_blockRange.ContainsNode(hiResult));
+    assert(BlockRange().ContainsNode(loResult));
+    assert(BlockRange().ContainsNode(hiResult));
     assert(loResult->Precedes(hiResult));
 
     GenTree* gtLong = new (m_compiler, GT_LONG) GenTreeOp(GT_LONG, TYP_LONG, loResult, hiResult);
-    m_blockRange.InsertAfter(gtLong, hiResult);
+    BlockRange().InsertAfter(gtLong, hiResult);
 
     use.ReplaceWith(m_compiler, gtLong);
 
-    assert(m_blockRange.CheckLIR(m_compiler));
+    assert(BlockRange().CheckLIR(m_compiler));
 
     return gtLong->gtNext;
 }
@@ -324,7 +323,7 @@ GenTree* DecomposeLongs::DecomposeLclVar(LIR::Use& use)
 
     GenTree* hiResult = m_compiler->gtNewLclLNode(varNum, TYP_INT);
     hiResult->CopyCosts(loResult);
-    m_blockRange.InsertAfter(hiResult, loResult);
+    BlockRange().InsertAfter(hiResult, loResult);
 
     if (varDsc->lvPromoted)
     {
@@ -376,7 +375,7 @@ GenTree* DecomposeLongs::DecomposeLclFld(LIR::Use& use)
                                                     TYP_INT,
                                                     loResult->gtLclOffs + 4);
     hiResult->CopyCosts(loResult);
-    m_blockRange.InsertAfter(hiResult, loResult);
+    BlockRange().InsertAfter(hiResult, loResult);
 
     return FinalizeDecomposition(use, loResult, hiResult);
 }
@@ -439,7 +438,7 @@ GenTree* DecomposeLongs::DecomposeStoreLclVar(LIR::Use& use)
 
     // 'tree' is going to steal the loRhs node for itself, so we need to remove the
     // GT_LONG node from the threading.
-    m_blockRange.Remove(rhs);
+    BlockRange().Remove(rhs);
 
     tree->gtOp.gtOp1 = loRhs;
     tree->gtType = TYP_INT;
@@ -451,9 +450,9 @@ GenTree* DecomposeLongs::DecomposeStoreLclVar(LIR::Use& use)
     m_compiler->lvaIncRefCnts(hiStore);
 
     hiStore->CopyCosts(tree);
-    m_blockRange.InsertAfter(hiStore, tree);
+    BlockRange().InsertAfter(hiStore, tree);
 
-    assert(m_blockRange.CheckLIR(m_compiler));
+    assert(BlockRange().CheckLIR(m_compiler));
     return hiStore->gtNext;
 }
 
@@ -484,11 +483,11 @@ GenTree* DecomposeLongs::DecomposeCast(LIR::Use& use)
         if (tree->gtFlags & GTF_UNSIGNED)
         {
             loResult = tree->gtGetOp1();
-            m_blockRange.Remove(tree);
+            BlockRange().Remove(tree);
 
             hiResult = new (m_compiler, GT_CNS_INT) GenTreeIntCon(TYP_INT, 0);
             hiResult->CopyCosts(loResult);
-            m_blockRange.InsertAfter(hiResult, loResult);
+            BlockRange().InsertAfter(hiResult, loResult);
         }
         else
         {
@@ -528,7 +527,7 @@ GenTree* DecomposeLongs::DecomposeCnsLng(LIR::Use& use)
 
     GenTree* hiResult = new (m_compiler, GT_CNS_INT) GenTreeIntCon(TYP_INT, hiVal);
     hiResult->CopyCosts(loResult);
-    m_blockRange.InsertAfter(hiResult, loResult);
+    BlockRange().InsertAfter(hiResult, loResult);
 
     return FinalizeDecomposition(use, loResult, hiResult);
 }
@@ -631,14 +630,14 @@ GenTree* DecomposeLongs::DecomposeStoreInd(LIR::Use& use)
     unsigned blockWeight = m_block->getBBWeight(m_compiler);
 
     // Save address to a temp. It is used in storeIndLow and storeIndHigh trees.
-    LIR::Use address(m_blockRange, &tree->gtOp.gtOp1, tree);
+    LIR::Use address(BlockRange(), &tree->gtOp.gtOp1, tree);
     address.ReplaceWithLclVar(m_compiler, blockWeight);
     JITDUMP("[DecomposeStoreInd]: Saving address tree to a temp var:\n");
     DISPTREE(address.Def());
 
     if (!gtLong->gtOp.gtOp1->OperIsLeaf())
     {
-        LIR::Use op1(m_blockRange, &gtLong->gtOp.gtOp1, gtLong);
+        LIR::Use op1(BlockRange(), &gtLong->gtOp.gtOp1, gtLong);
         op1.ReplaceWithLclVar(m_compiler, blockWeight);
         JITDUMP("[DecomposeStoreInd]: Saving low data tree to a temp var:\n");
         DISPTREE(op1.Def());
@@ -646,7 +645,7 @@ GenTree* DecomposeLongs::DecomposeStoreInd(LIR::Use& use)
 
     if (!gtLong->gtOp.gtOp2->OperIsLeaf())
     {
-        LIR::Use op2(m_blockRange, &gtLong->gtOp.gtOp2, gtLong);
+        LIR::Use op2(BlockRange(), &gtLong->gtOp.gtOp2, gtLong);
         op2.ReplaceWithLclVar(m_compiler, blockWeight);
         JITDUMP("[DecomposeStoreInd]: Saving high data tree to a temp var:\n");
         DISPTREE(op2.Def());
@@ -705,8 +704,8 @@ GenTree* DecomposeLongs::DecomposeStoreInd(LIR::Use& use)
     //
     // (editor brace matching compensation: }}}}}}}}})
 
-    m_blockRange.Remove(gtLong);
-    m_blockRange.Remove(dataHigh);
+    BlockRange().Remove(gtLong);
+    BlockRange().Remove(dataHigh);
     storeIndLow->gtOp.gtOp2 = dataLow;
     storeIndLow->gtType = TYP_INT;
 
@@ -729,12 +728,12 @@ GenTree* DecomposeLongs::DecomposeStoreInd(LIR::Use& use)
 
     m_compiler->gtPrepareCost(storeIndHigh);
 
-    m_blockRange.InsertAfter(dataHigh, storeIndLow);
-    m_blockRange.InsertAfter(addrBaseHigh, dataHigh);
-    m_blockRange.InsertAfter(addrHigh, addrBaseHigh);
-    m_blockRange.InsertAfter(storeIndHigh, addrHigh);
+    BlockRange().InsertAfter(dataHigh, storeIndLow);
+    BlockRange().InsertAfter(addrBaseHigh, dataHigh);
+    BlockRange().InsertAfter(addrHigh, addrBaseHigh);
+    BlockRange().InsertAfter(storeIndHigh, addrHigh);
 
-    assert(m_blockRange.CheckLIR(m_compiler));
+    assert(BlockRange().CheckLIR(m_compiler));
 
     return storeIndHigh;
 
@@ -795,7 +794,7 @@ GenTree* DecomposeLongs::DecomposeInd(LIR::Use& use)
 {
     GenTree* indLow = use.Def();
 
-    LIR::Use address(m_blockRange, &indLow->gtOp.gtOp1, indLow);
+    LIR::Use address(BlockRange(), &indLow->gtOp.gtOp1, indLow);
     address.ReplaceWithLclVar(m_compiler, m_block->getBBWeight(m_compiler));
     JITDUMP("[DecomposeInd]: Saving addr tree to a temp var:\n");
     DISPTREE(address.Def());
@@ -813,9 +812,9 @@ GenTree* DecomposeLongs::DecomposeInd(LIR::Use& use)
     m_compiler->gtPrepareCost(indHigh);
 
     // Insert the nodes into the block
-    m_blockRange.InsertAfter(addrBaseHigh, indLow);
-    m_blockRange.InsertAfter(addrHigh, addrBaseHigh);
-    m_blockRange.InsertAfter(indHigh, addrHigh);
+    BlockRange().InsertAfter(addrBaseHigh, indLow);
+    BlockRange().InsertAfter(addrHigh, addrBaseHigh);
+    BlockRange().InsertAfter(indHigh, addrHigh);
 
     return FinalizeDecomposition(use, indLow, indHigh);
 }
@@ -840,7 +839,7 @@ GenTree* DecomposeLongs::DecomposeNot(LIR::Use& use)
     GenTree* loOp1 = gtLong->gtGetOp1();
     GenTree* hiOp1 = gtLong->gtGetOp2();
 
-    m_blockRange.Remove(gtLong);
+    BlockRange().Remove(gtLong);
 
     GenTree* loResult = tree;
     loResult->gtType = TYP_INT;
@@ -848,7 +847,7 @@ GenTree* DecomposeLongs::DecomposeNot(LIR::Use& use)
 
     GenTree* hiResult = new (m_compiler, GT_NOT) GenTreeOp(GT_NOT, TYP_INT, hiOp1, nullptr);
     hiResult->CopyCosts(loResult);
-    m_blockRange.InsertAfter(hiResult, loResult);
+    BlockRange().InsertAfter(hiResult, loResult);
 
     return FinalizeDecomposition(use, loResult, hiResult);
 }
@@ -873,10 +872,10 @@ GenTree* DecomposeLongs::DecomposeNeg(LIR::Use& use)
 
     unsigned blockWeight = m_block->getBBWeight(m_compiler);
 
-    LIR::Use op1(m_blockRange, &gtLong->gtOp.gtOp1, gtLong);
+    LIR::Use op1(BlockRange(), &gtLong->gtOp.gtOp1, gtLong);
     op1.ReplaceWithLclVar(m_compiler, blockWeight);
 
-    LIR::Use op2(m_blockRange, &gtLong->gtOp.gtOp2, gtLong);
+    LIR::Use op2(BlockRange(), &gtLong->gtOp.gtOp2, gtLong);
     op2.ReplaceWithLclVar(m_compiler, blockWeight);
 
     // Neither GT_NEG nor the introduced temporaries have side effects.
@@ -884,7 +883,7 @@ GenTree* DecomposeLongs::DecomposeNeg(LIR::Use& use)
     GenTree* loOp1 = gtLong->gtGetOp1();
     GenTree* hiOp1 = gtLong->gtGetOp2();
 
-    m_blockRange.Remove(gtLong);
+    BlockRange().Remove(gtLong);
 
     GenTree* loResult = tree;
     loResult->gtType = TYP_INT;
@@ -898,9 +897,9 @@ GenTree* DecomposeLongs::DecomposeNeg(LIR::Use& use)
     // Annotate new nodes with costs. This will re-cost the hiOp1 tree as well.
     m_compiler->gtPrepareCost(hiResult);
 
-    m_blockRange.InsertAfter(zero, loResult);
-    m_blockRange.InsertAfter(hiAdjust, zero);
-    m_blockRange.InsertAfter(hiResult, hiAdjust);
+    BlockRange().InsertAfter(zero, loResult);
+    BlockRange().InsertAfter(hiAdjust, zero);
+    BlockRange().InsertAfter(hiResult, hiAdjust);
 
     return FinalizeDecomposition(use, loResult, hiResult);
 }
@@ -961,8 +960,8 @@ GenTree* DecomposeLongs::DecomposeArith(LIR::Use& use)
             "Can't decompose expression tree TYP_LONG node");
 
     // Now, remove op1 and op2 from the node list.
-    m_blockRange.Remove(op1);
-    m_blockRange.Remove(op2);
+    BlockRange().Remove(op1);
+    BlockRange().Remove(op2);
 
     // We will reuse "tree" for the loResult, which will now be of TYP_INT, and its operands
     // will be the lo halves of op1 from above.
@@ -974,7 +973,7 @@ GenTree* DecomposeLongs::DecomposeArith(LIR::Use& use)
 
     GenTree* hiResult = new (m_compiler, oper) GenTreeOp(GetHiOper(oper), TYP_INT, hiOp1, hiOp2);
     hiResult->CopyCosts(loResult);
-    m_blockRange.InsertAfter(hiResult, loResult);
+    BlockRange().InsertAfter(hiResult, loResult);
 
     if ((oper == GT_ADD) || (oper == GT_SUB))
     {

--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -70,7 +70,6 @@ void DecomposeLongs::DecomposeBlock(BasicBlock* block)
     assert(block->isEmpty() || block->IsLIR());
 
     m_block = block;
-    BlockRange() = LIR::AsRange(block);
 
     GenTree* node = BlockRange().FirstNonPhiNode();
     while (node != nullptr)
@@ -284,8 +283,8 @@ GenTree* DecomposeLongs::FinalizeDecomposition(LIR::Use& use, GenTree* loResult,
     assert(use.IsInitialized());
     assert(loResult != nullptr);
     assert(hiResult != nullptr);
-    assert(BlockRange().ContainsNode(loResult));
-    assert(BlockRange().ContainsNode(hiResult));
+    assert(BlockRange().Contains(loResult));
+    assert(BlockRange().Contains(hiResult));
     assert(loResult->Precedes(hiResult));
 
     GenTree* gtLong = new (m_compiler, GT_LONG) GenTreeOp(GT_LONG, TYP_LONG, loResult, hiResult);

--- a/src/jit/decomposelongs.h
+++ b/src/jit/decomposelongs.h
@@ -29,6 +29,10 @@ public:
     void DecomposeBlock(BasicBlock* block);
     
 private:
+    inline LIR::Range& BlockRange() const
+    {
+        return LIR::AsRange(m_block);
+    }
 
     // Driver functions
     GenTree* DecomposeNode(LIR::Use& use);
@@ -55,7 +59,6 @@ private:
     // Data
     Compiler* m_compiler;
     BasicBlock* m_block;
-    LIR::Range m_blockRange;
 };
 
 #endif // _DECOMPOSELONGS_H_

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -13621,7 +13621,7 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
     while (++jmpTab, --jmpCnt);
 
     GenTreeStmt* switchStmt = nullptr;
-    LIR::Range* blockRange;
+    LIR::Range* blockRange = nullptr;
 
     GenTree* switchTree;
     if (block->IsLIR())

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -8785,14 +8785,12 @@ BasicBlock* Compiler::fgSplitBlockAfterNode(BasicBlock* curr, GenTree* node)
 
     if (node != nullptr)
     {
-        LIR::Range currBBRange = LIR::AsRange(curr);
+        LIR::Range& currBBRange = LIR::AsRange(curr);
 
-        if (node != curr->bbLastNode)
+        if (node != currBBRange.LastNode())
         {
-            LIR::Range nodesToMove = LIR::AsRange(node->gtNext, curr->bbLastNode);
-
-            currBBRange.Remove(nodesToMove);
-            LIR::AsRange(newBlock).InsertAtBeginning(nodesToMove);
+            LIR::Range nodesToMove = currBBRange.Remove(node->gtNext, currBBRange.LastNode());
+            LIR::AsRange(newBlock).InsertAtBeginning(std::move(nodesToMove));
         }
 
         // Update the IL offsets of the blocks to match the split.
@@ -8986,9 +8984,10 @@ void Compiler::fgSimpleLowering()
             for (GenTreePtr tree = stmt->gtStmtList; tree; tree = tree->gtNext)
             {
 #else
-        LIR::Range range = LIR::AsRange(block);
-        for (GenTree* tree = range.Begin(), *end = range.End(); tree != end; tree = tree->gtNext)
+        LIR::Range& range = LIR::AsRange(block);
+        for (GenTree* tree : range)
         {
+            {
 #endif
                 if (tree->gtOper == GT_ARR_LENGTH)
                 {
@@ -9053,9 +9052,7 @@ void Compiler::fgSimpleLowering()
                     fgSetRngChkTarget(tree, false);
                 }
             }
-#ifdef LEGACY_BACKEND
         }
-#endif
     }
 
 #ifdef DEBUG
@@ -9769,49 +9766,40 @@ void                Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNe
     // control-flow choice was constant-folded away.  So probably phi's need to go away,
     // as well, in favor of one of the incoming branches.  Or at least be modified.
 
-    assert((block->IsLIR() == bNext->IsLIR()) || (block->IsLIR() && bNext->isEmpty()) || (block->isEmpty() && bNext->IsLIR()));
+    assert(block->IsLIR() == bNext->IsLIR());
     if (block->IsLIR() || bNext->IsLIR())
     {
-        LIR::Range blockRange = LIR::AsRange(block);
-        LIR::Range nextRange = LIR::AsRange(bNext);
-
-        GenTree* blockBegin = blockRange.Begin();
-        GenTree* blockFirstNonPhi = blockRange.FirstNonPhiNode();
-
-        GenTree* nextBegin = nextRange.Begin();
-        GenTree* nextFirstNonPhi = nextRange.FirstNonPhiNode();
-
-        GenTree* insertionPoint = nullptr;
-        if (blockBegin != blockFirstNonPhi)
-        {
-            insertionPoint = blockFirstNonPhi != blockRange.End() ? blockFirstNonPhi->gtPrev : blockRange.EndExclusive();
-        }
+        LIR::Range& blockRange = LIR::AsRange(block);
+        LIR::Range& nextRange = LIR::AsRange(bNext);
 
         // Does the next block have any phis?
-        if (nextBegin != nextFirstNonPhi)
+        GenTree* nextFirstNonPhi = nullptr;
+        LIR::ReadOnlyRange nextPhis = nextRange.PhiNodes();
+        if (!nextPhis.IsEmpty())
         {
-            GenTree* lastPhi = nextFirstNonPhi != nextRange.End() ? nextFirstNonPhi->gtPrev : nextRange.EndExclusive();
+            GenTree* blockFirstNonPhi = blockRange.FirstNonPhiNode();
+            nextFirstNonPhi = nextPhis.LastNode()->gtNext;
 
-            LIR::Range nextPhis = LIR::AsRange(nextBegin, lastPhi);
-            nextRange.Remove(nextPhis);
-
-            if (insertionPoint == nullptr)
+            LIR::Range phisToMove = nextRange.Remove(std::move(nextPhis));
+            if (blockFirstNonPhi == nullptr)
             {
-                blockRange.InsertAtBeginning(nextPhis);
+                blockRange.InsertAtEnd(std::move(phisToMove));
             }
             else
             {
-                blockRange.InsertAfter(nextPhis, insertionPoint);
+                blockRange.InsertBefore(std::move(phisToMove), blockFirstNonPhi);
             }
+        }
+        else
+        {
+            nextFirstNonPhi = nextRange.FirstNode();
         }
 
         // Does the block have any other code?
-        if (nextFirstNonPhi != nextRange.End())
+        if (nextFirstNonPhi != nullptr)
         {
-            LIR::Range nextNodes = LIR::AsRange(nextFirstNonPhi, nextRange.EndExclusive());
-            nextRange.Remove(nextNodes);
-
-            blockRange.InsertAfter(nextNodes, blockRange.EndExclusive());
+            LIR::Range nextNodes = nextRange.Remove(nextFirstNonPhi, nextRange.LastNode());
+            blockRange.InsertAfter(std::move(nextNodes), blockRange.LastNode());
         }
 
         assert(blockRange.CheckLIR(this));
@@ -10228,17 +10216,12 @@ void                Compiler::fgUnreachableBlock(BasicBlock* block)
 
     if (block->IsLIR())
     {
-        LIR::Range blockRange = LIR::AsRange(block);
-
-        // Skip phis when decrementing ref counts.
-        GenTree* firstNonPhiNode = blockRange.FirstNonPhiNode();
-        if (firstNonPhiNode != blockRange.End())
+        LIR::Range& blockRange = LIR::AsRange(block);
+        if (!blockRange.IsEmpty())
         {
-            LIR::DecRefCnts(this, block, LIR::AsRange(firstNonPhiNode, blockRange.EndExclusive()));
+            LIR::DecRefCnts(this, block, blockRange.NonPhiNodes());
+            blockRange.Remove(blockRange.FirstNode(), blockRange.LastNode());
         }
-
-        block->bbTreeList = nullptr;
-        block->bbLastNode = nullptr;
     }
     else
     {
@@ -10302,21 +10285,21 @@ void                Compiler::fgRemoveJTrue(BasicBlock *block)
 
     if (block->IsLIR())
     {
-        LIR::Range blockRange = LIR::AsRange(block);
+        LIR::Range& blockRange = LIR::AsRange(block);
 
-        GenTree* test = blockRange.EndExclusive();
+        GenTree* test = blockRange.LastNode();
         assert(test->OperGet() == GT_JTRUE);
 
         bool isClosed;
         unsigned sideEffects;
-        LIR::Range testRange = blockRange.GetTreeRange(test, &isClosed, &sideEffects);
+        LIR::ReadOnlyRange testRange = blockRange.GetTreeRange(test, &isClosed, &sideEffects);
 
         if (isClosed && ((sideEffects & GTF_ALL_EFFECT) == 0))
         {
             // If the jump and its operands form a contiguous, side-effect-free range,
             // remove them.
-            blockRange.Remove(testRange);
             LIR::DecRefCnts(this, block, testRange);
+            blockRange.Remove(std::move(testRange));
         }
         else
         {
@@ -13638,13 +13621,13 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
     while (++jmpTab, --jmpCnt);
 
     GenTreeStmt* switchStmt = nullptr;
-    LIR::Range blockRange;
+    LIR::Range* blockRange;
 
     GenTree* switchTree;
     if (block->IsLIR())
     {
-        blockRange = LIR::AsRange(block);
-        switchTree = blockRange.EndExclusive();
+        blockRange = &LIR::AsRange(block);
+        switchTree = blockRange->LastNode();
 
         assert(switchTree->OperGet() == GT_SWITCH_TABLE);
     }
@@ -13684,15 +13667,15 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
         {
             bool isClosed;
             unsigned sideEffects;
-            LIR::Range switchTreeRange = blockRange.GetTreeRange(switchTree, &isClosed, &sideEffects);
+            LIR::ReadOnlyRange switchTreeRange = blockRange->GetTreeRange(switchTree, &isClosed, &sideEffects);
 
             // The switch tree should form a contiguous, side-effect free range by construction. See
             // Lowering::LowerSwitch for details.
             assert(isClosed);
             assert((sideEffects & GTF_ALL_EFFECT) == 0);
 
-            blockRange.Remove(switchTreeRange);
             LIR::DecRefCnts(this, block, switchTreeRange);
+            blockRange->Remove(std::move(switchTreeRange));
         }
         else
         {
@@ -13774,7 +13757,7 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
         {
             GenTree* jumpTable = switchTree->gtOp.gtOp2;
             assert(jumpTable->OperGet() == GT_JMPTABLE);
-            blockRange.Remove(jumpTable);
+            blockRange->Remove(jumpTable);
         }
 
         // Change the GT_SWITCH(switchVal) into GT_JTRUE(GT_EQ(switchVal==0)).
@@ -13803,8 +13786,8 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
 
         if (block->IsLIR())
         {
-            blockRange.InsertAfter(zeroConstNode, switchVal);
-            blockRange.InsertAfter(condNode, zeroConstNode);
+            blockRange->InsertAfter(zeroConstNode, switchVal);
+            blockRange->InsertAfter(condNode, zeroConstNode);
         }
         else
         {
@@ -14041,20 +14024,20 @@ bool Compiler::fgOptimizeBranchToNext(BasicBlock* block, BasicBlock* bNext, Basi
 
         if (block->IsLIR())
         {
-            LIR::Range blockRange = LIR::AsRange(block);
-            GenTree* jmp = blockRange.EndExclusive();
+            LIR::Range& blockRange = LIR::AsRange(block);
+            GenTree* jmp = blockRange.LastNode();
             assert(jmp->OperGet() == GT_JTRUE);
 
             bool isClosed;
             unsigned sideEffects;
-            LIR::Range jmpRange = blockRange.GetTreeRange(jmp, &isClosed, &sideEffects);
+            LIR::ReadOnlyRange jmpRange = blockRange.GetTreeRange(jmp, &isClosed, &sideEffects);
 
             if (isClosed && ((sideEffects & GTF_ALL_EFFECT) == 0))
             {
                 // If the jump and its operands form a contiguous, side-effect-free range,
                 // remove them.
-                blockRange.Remove(jmpRange);
                 LIR::DecRefCnts(this, block, jmpRange);
+                blockRange.Remove(std::move(jmpRange));
             }
             else
             {
@@ -16082,16 +16065,7 @@ REPEAT:;
 #endif // DEBUG
                         /* Reverse the jump condition */
 
-                        GenTree* test;
-                        if (block->IsLIR())
-                        {
-                            test = block->bbLastNode;
-                        }
-                        else
-                        {
-                            test = block->lastTopLevelStmt()->gtStmt.gtStmtExpr;
-                        }
-
+                        GenTree* test = block->lastNode();
                         noway_assert(test->gtOper == GT_JTRUE);
 
                         GenTree* cond = gtReverseCond(test->gtOp.gtOp1);

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -9767,7 +9767,7 @@ void                Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNe
     // as well, in favor of one of the incoming branches.  Or at least be modified.
 
     assert(block->IsLIR() == bNext->IsLIR());
-    if (block->IsLIR() || bNext->IsLIR())
+    if (block->IsLIR())
     {
         LIR::Range& blockRange = LIR::AsRange(block);
         LIR::Range& nextRange = LIR::AsRange(bNext);
@@ -9777,17 +9777,17 @@ void                Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNe
         LIR::ReadOnlyRange nextPhis = nextRange.PhiNodes();
         if (!nextPhis.IsEmpty())
         {
-            GenTree* blockFirstNonPhi = blockRange.FirstNonPhiNode();
+            GenTree* blockLastPhi = blockRange.LastPhiNode();
             nextFirstNonPhi = nextPhis.LastNode()->gtNext;
 
             LIR::Range phisToMove = nextRange.Remove(std::move(nextPhis));
-            if (blockFirstNonPhi == nullptr)
+            if (blockLastPhi == nullptr)
             {
-                blockRange.InsertAtEnd(std::move(phisToMove));
+                blockRange.InsertAtBeginning(std::move(phisToMove));
             }
             else
             {
-                blockRange.InsertBefore(std::move(phisToMove), blockFirstNonPhi);
+                blockRange.InsertAfter(std::move(phisToMove), blockLastPhi);
             }
         }
         else

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -13348,7 +13348,10 @@ BasicBlock *        Compiler::bbNewBasicBlock(BBjumpKinds jumpKind)
         block->bbNum = ++fgBBNumMax;
     }
 
-    block->bbIsLIR = compRationalIRForm ? 1 : 0;
+    if (compRationalIRForm)
+    {
+        block->bbFlags |= BBF_IS_LIR;
+    }
 
     block->bbRefs     = 1;
     block->bbWeight   = BB_UNITY_WEIGHT;

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -13348,6 +13348,8 @@ BasicBlock *        Compiler::bbNewBasicBlock(BBjumpKinds jumpKind)
         block->bbNum = ++fgBBNumMax;
     }
 
+    block->bbIsLIR = compRationalIRForm ? 1 : 0;
+
     block->bbRefs     = 1;
     block->bbWeight   = BB_UNITY_WEIGHT;
 

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -448,8 +448,40 @@ LIR::Range::Range(GenTree* firstNode, GenTree* lastNode)
 }
 
 //------------------------------------------------------------------------
+// LIR::Range::LastPhiNode: Returns the last phi node in the range or
+//                          `nullptr` if no phis exist.
+//
+GenTree* LIR::Range::LastPhiNode() const
+{
+    GenTree* lastPhiNode = nullptr;
+    for (GenTree* node : *this)
+    {
+        if (node->OperGet() == GT_PHI_ARG)
+        {
+            lastPhiNode = node;
+            continue;
+        }
+        else if (node->OperGet() == GT_PHI)
+        {
+            lastPhiNode = node;
+            continue;
+        }
+        else if (node->IsPhiDefn())
+        {
+            lastPhiNode = node;
+            continue;
+        }
+
+        break;
+    }
+
+    return lastPhiNode;
+}
+
+//------------------------------------------------------------------------
 // LIR::Range::FirstNonPhiNode: Returns the first non-phi node in the
-//                              range.
+//                              range or `nullptr` if no non-phi nodes
+//                              exist.
 //
 GenTree* LIR::Range::FirstNonPhiNode() const
 {
@@ -503,13 +535,13 @@ GenTree* LIR::Range::FirstNonPhiOrCatchArgNode() const
 //
 LIR::ReadOnlyRange LIR::Range::PhiNodes() const
 {
-    GenTree* firstNonPhiNode = FirstNonPhiNode();
-    if (firstNonPhiNode == m_firstNode)
+    GenTree* lastPhiNode = LastPhiNode();
+    if (lastPhiNode == nullptr)
     {
         return ReadOnlyRange();
     }
 
-    return ReadOnlyRange(m_firstNode, firstNonPhiNode == nullptr ? m_lastNode : firstNonPhiNode->gtPrev);
+    return ReadOnlyRange(m_firstNode, lastPhiNode);
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -133,8 +133,7 @@ bool LIR::Use::IsInitialized() const
 void LIR::Use::AssertIsValid() const
 {
     assert(IsInitialized());
-    assert(m_range->IsValid());
-    assert(m_range->ContainsNode(m_user));
+    assert(m_range->Contains(m_user));
     assert(Def() != nullptr);
 
     GenTree** useEdge = nullptr;
@@ -196,8 +195,8 @@ void LIR::Use::ReplaceWith(Compiler* compiler, GenTree* replacement)
     assert(IsInitialized());
     assert(compiler != nullptr);
     assert(replacement != nullptr);
-    assert(IsDummyUse() || m_range->ContainsNode(m_user));
-    assert(m_range->ContainsNode(replacement));
+    assert(IsDummyUse() || m_range->Contains(m_user));
+    assert(m_range->Contains(replacement));
 
     GenTree* replacedNode = *m_edge;
 
@@ -262,8 +261,8 @@ unsigned LIR::Use::ReplaceWithLclVar(Compiler* compiler, unsigned blockWeight, u
 {
     assert(IsInitialized());
     assert(compiler != nullptr);
-    assert(m_range->ContainsNode(m_user));
-    assert(m_range->ContainsNode(*m_edge));
+    assert(m_range->Contains(m_user));
+    assert(m_range->Contains(*m_edge));
 
     GenTree* node = *m_edge;
 
@@ -292,213 +291,160 @@ unsigned LIR::Use::ReplaceWithLclVar(Compiler* compiler, unsigned blockWeight, u
     return lclNum;
 }
 
-LIR::Range::Range()
-    : m_firstNodeSlot(nullptr)
-    , m_lastNodeSlot(nullptr)
+LIR::ReadOnlyRange::ReadOnlyRange()
+    : m_firstNode(nullptr)
+    , m_lastNode(nullptr)
 {
 }
 
+LIR::ReadOnlyRange::ReadOnlyRange(ReadOnlyRange&& other)
+    : m_firstNode(other.m_firstNode)
+    , m_lastNode(other.m_lastNode)
+{
+#ifdef DEBUG
+    other.m_firstNode = nullptr;
+    other.m_lastNode = nullptr;
+#endif
+}
+
 //------------------------------------------------------------------------
-// LIR::Range::Range: Creates a `Range` value given two locations that
-//                    store the first and last node in the range.
+// LIR::ReadOnlyRange::ReadOnlyRange:
+//    Creates a `ReadOnlyRange` value given the first and last node in
+//    the range.
 //
 // Arguments:
-//    firstNodeSlot - The storage for the first node in the range.
-//    lastNodeSlot  - The storage for the last node in the range.
+//    firstNode - The first node in the range.
+//    lastNode  - The last node in the range.
 //
-LIR::Range::Range(GenTree** firstNodeSlot, GenTree** lastNodeSlot)
-    : m_firstNodeSlot(firstNodeSlot)
-    , m_lastNodeSlot(lastNodeSlot)
-    , m_isSimpleRange(false)
+LIR::ReadOnlyRange::ReadOnlyRange(GenTree* firstNode, GenTree* lastNode)
+    : m_firstNode(firstNode)
+    , m_lastNode(lastNode)
 {
-    assert(firstNodeSlot != nullptr);
-    assert(lastNodeSlot != nullptr);
-    assert(firstNodeSlot != lastNodeSlot);
+    assert((m_firstNode == nullptr) == (m_lastNode == nullptr));
+    assert((m_firstNode == m_lastNode) || (Contains(m_lastNode)));
+}
 
-    assert((FirstNode() != nullptr) == (LastNode() != nullptr));
-    assert((FirstNode() == LastNode()) || ContainsNode(LastNode()));
+
+//------------------------------------------------------------------------
+// LIR::ReadOnlyRange::FirstNode: Returns the first node in the range.
+//
+GenTree* LIR::ReadOnlyRange::FirstNode() const
+{
+    return m_firstNode;
+}
+
+//------------------------------------------------------------------------
+// LIR::ReadOnlyRange::LastNode: Returns the last node in the range.
+//
+GenTree* LIR::ReadOnlyRange::LastNode() const
+{
+    return m_lastNode;
+}
+
+//------------------------------------------------------------------------
+// LIR::ReadOnlyRange::IsEmpty: Returns true if the range is empty; false
+//                              otherwise.
+//
+bool LIR::ReadOnlyRange::IsEmpty() const
+{
+    assert((m_firstNode == nullptr) == (m_lastNode == nullptr));
+    return m_firstNode == nullptr;
+}
+
+//------------------------------------------------------------------------
+// LIR::ReadOnlyRange::begin: Returns an iterator positioned at the first
+//                            node in the range.
+//
+LIR::ReadOnlyRange::Iterator LIR::ReadOnlyRange::begin() const
+{
+    return Iterator(m_firstNode);
+}
+
+//------------------------------------------------------------------------
+// LIR::ReadOnlyRange::end: Returns an iterator positioned after the last
+//                          node in the range.
+//
+LIR::ReadOnlyRange::Iterator LIR::ReadOnlyRange::end() const
+{
+    return Iterator(m_lastNode == nullptr ? nullptr : m_lastNode->gtNext);
+}
+
+//------------------------------------------------------------------------
+// LIR::ReadOnlyRange::rbegin: Returns an iterator positioned at the last
+//                             node in the range.
+//
+LIR::ReadOnlyRange::ReverseIterator LIR::ReadOnlyRange::rbegin() const
+{
+    return ReverseIterator(m_lastNode);
+}
+
+//------------------------------------------------------------------------
+// LIR::ReadOnlyRange::rend: Returns an iterator positioned before the first
+//                           node in the range.
+//
+LIR::ReadOnlyRange::ReverseIterator LIR::ReadOnlyRange::rend() const
+{
+    return ReverseIterator(m_firstNode == nullptr ? nullptr : m_firstNode->gtPrev);
+}
+
+#ifdef DEBUG
+
+//------------------------------------------------------------------------
+// LIR::ReadOnlyRange::Contains: Indicates whether or not this range
+//                               contains a given node.
+//
+// Arguments:
+//    node - The node to find.
+//
+// Return Value: True if this range contains the given node; false
+//               otherwise.
+//
+bool LIR::ReadOnlyRange::Contains(GenTree* node) const
+{
+    assert(node != nullptr);
+
+    // TODO(pdg): derive this from the # of nodes in the function as well as
+    // the debug level. Checking small functions is pretty cheap; checking
+    // large functions is not.
+    if (JitConfig.JitExpensiveDebugCheckLevel() < 2)
+    {
+        return true;
+    }
+
+    for (GenTree* n : *this)
+    {
+        if (n == node)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+#endif
+
+LIR::Range::Range()
+    : ReadOnlyRange()
+{
+}
+
+LIR::Range::Range(Range&& other)
+    : ReadOnlyRange(std::move(other))
+{
 }
 
 //------------------------------------------------------------------------
 // LIR::Range::Range: Creates a `Range` value given the first and last
-//                    node in the range. When this constructor is called,
-//                    the Range itself will store the nodes.
+//                    node in the range.
 //
 // Arguments:
 //    firstNode - The first node in the range.
 //    lastNode  - The last node in the range.
 //
 LIR::Range::Range(GenTree* firstNode, GenTree* lastNode)
-    : m_firstNodeSlot(reinterpret_cast<GenTree**>(firstNode))
-    , m_lastNodeSlot(reinterpret_cast<GenTree**>(lastNode))
-    , m_isSimpleRange(true)
+    : ReadOnlyRange(firstNode, lastNode)
 {
-    assert((FirstNode() != nullptr) == (LastNode() != nullptr));
-    assert((FirstNode() == LastNode()) || ContainsNode(LastNode()));
-}
-
-
-//------------------------------------------------------------------------
-// LIR::Range::FirstNode: Returns a reference to the first node in the
-//                        range.
-//
-// Note: this method is private because it allows the caller to
-// subsequently modify the value stored in `m_firstNodeSlot`.
-//
-GenTree*& LIR::Range::FirstNode() const
-{
-    assert(m_isSimpleRange || m_firstNodeSlot != nullptr);
-    if (!m_isSimpleRange)
-    {
-        return *m_firstNodeSlot;
-    }
-
-    return *reinterpret_cast<GenTree**>(&const_cast<Range*>(this)->m_firstNodeSlot);
-}
-
-//------------------------------------------------------------------------
-// LIR::Range::LastNode: Returns a reference to the last node in the
-//                       range.
-// Note: this method is private because it allows the caller to
-// subsequently modify the value stored in `m_lastNodeSlot`.
-//
-GenTree*& LIR::Range::LastNode() const
-{
-    assert(m_isSimpleRange || m_lastNodeSlot != nullptr);
-    if (!m_isSimpleRange)
-    {
-        return *m_lastNodeSlot;
-    }
-
-    return *reinterpret_cast<GenTree**>(&const_cast<Range*>(this)->m_lastNodeSlot);
-}
-
-//------------------------------------------------------------------------
-// LIR::Range::IsValid: Returns true if the `Range` value is valid.
-//
-// A `Range` is considered valid for the purposes of this method if its
-// storage has been initialized and it is either empty or has non-null
-// values for its first and last node. This method does not check whether
-// or not the first and last nodes actually define a range.
-//
-// Arguments:
-//     None.
-//
-// Return Value:
-//     'true' if the Range is valid.
-//
-bool LIR::Range::IsValid() const
-{
-    if ((m_firstNodeSlot == nullptr) || (m_lastNodeSlot == nullptr))
-    {
-        return false;
-    }
-
-    if (IsEmpty())
-    {
-        return true;
-    }
-
-    if ((FirstNode() == nullptr) || (LastNode() == nullptr))
-    {
-        return false;
-    }
-
-    return true;
-}
-
-//------------------------------------------------------------------------
-// LIR::Range::IsEmpty: Returns true if the range is empty; false
-//                      otherwise.
-//
-bool LIR::Range::IsEmpty() const
-{
-    if (FirstNode() == nullptr)
-    {
-        assert(LastNode() == nullptr);
-        return true;
-    }
-    else
-    {
-        return false;
-    }
-}
-
-//------------------------------------------------------------------------
-// LIR::Range::IsSubRange: Returns true if the range is a subsequence of
-//                         another range; false otherwise.
-//
-bool LIR::Range::IsSubRange() const
-{
-    return !IsEmpty() && ((FirstNode()->gtPrev != nullptr) || (LastNode()->gtNext != nullptr));
-}
-
-//------------------------------------------------------------------------
-// LIR::Range::Begin: Returns the first node in the range.
-//
-GenTree* LIR::Range::Begin() const
-{
-    return FirstNode();
-}
-
-//------------------------------------------------------------------------
-// LIR::Range::End: Returns a value that can be used during iteration to
-//                  find the end of the range. Note that this value is not
-//                  the last node in the range; rather, it is the node
-//                  that follows the last node or null.
-//
-GenTree* LIR::Range::End() const
-{
-    return IsEmpty() ? nullptr : LastNode()->gtNext;
-}
-
-
-//------------------------------------------------------------------------
-// LIR::Range::EndExclusive: Returns a value that can be used during iteration to
-//                  find the end of the range, but exclusive of the last element
-//                  of the range (that is, the last element will not be included
-//                  in the iteration).
-//
-GenTree* LIR::Range::EndExclusive() const
-{
-    return IsEmpty() ? nullptr : LastNode();
-}
-
-//------------------------------------------------------------------------
-// LIR::Range::begin: Returns an iterator positioned at the first node in
-//                    the range.
-//
-LIR::Range::Iterator LIR::Range::begin() const
-{
-    return Iterator(Begin());
-}
-
-//------------------------------------------------------------------------
-// LIR::Range::end: Returns an iterator positioned at the last node in the
-//                  range.
-//
-LIR::Range::Iterator LIR::Range::end() const
-{
-    return Iterator(End());
-}
-
-//------------------------------------------------------------------------
-// LIR::Range::rbegin: Returns an iterator positioned at the last node in
-//                    the range.
-//
-LIR::Range::ReverseIterator LIR::Range::rbegin() const
-{
-    return ReverseIterator(EndExclusive());
-}
-
-//------------------------------------------------------------------------
-// LIR::Range::rend: Returns an iterator positioned at the first node in the
-//                  range.
-//
-LIR::Range::ReverseIterator LIR::Range::rend() const
-{
-    GenTree* theEnd = IsEmpty() ? nullptr : Begin()->gtPrev;
-    return ReverseIterator(theEnd);
 }
 
 //------------------------------------------------------------------------
@@ -507,10 +453,7 @@ LIR::Range::ReverseIterator LIR::Range::rend() const
 //
 GenTree* LIR::Range::FirstNonPhiNode() const
 {
-    assert(IsValid());
-
-    GenTree* node, *end;
-    for (node = Begin(), end = End(); node != end; node = node->gtNext)
+    for (GenTree* node : *this)
     {
         if (node->OperGet() == GT_PHI_ARG)
         {
@@ -525,10 +468,10 @@ GenTree* LIR::Range::FirstNonPhiNode() const
             continue;
         }
 
-        break;
+        return node;
     }
 
-    return node;
+    return nullptr;
 }
 
 //------------------------------------------------------------------------
@@ -538,10 +481,7 @@ GenTree* LIR::Range::FirstNonPhiNode() const
 //
 GenTree* LIR::Range::FirstNonPhiOrCatchArgNode() const
 {
-    assert(IsValid());
-
-    GenTree* node, *end;
-    for (node = FirstNonPhiNode(), end = End(); node != end; node = node->gtNext)
+    for (GenTree* node : NonPhiNodes())
     {
         if (node->OperGet() == GT_CATCH_ARG)
         {
@@ -552,10 +492,39 @@ GenTree* LIR::Range::FirstNonPhiOrCatchArgNode() const
             continue;
         }
 
-        break;
+        return node;
     }
 
-    return node;
+    return nullptr;
+}
+
+//------------------------------------------------------------------------
+// LIR::Range::PhiNodes: Returns the range of phi nodes inside this range.
+//
+LIR::ReadOnlyRange LIR::Range::PhiNodes() const
+{
+    GenTree* firstNonPhiNode = FirstNonPhiNode();
+    if (firstNonPhiNode == m_firstNode)
+    {
+        return ReadOnlyRange();
+    }
+
+    return ReadOnlyRange(m_firstNode, firstNonPhiNode == nullptr ? m_lastNode : firstNonPhiNode->gtPrev);
+}
+
+//------------------------------------------------------------------------
+// LIR::Range::PhiNodes: Returns the range of non-phi nodes inside this
+//                       range.
+//
+LIR::ReadOnlyRange LIR::Range::NonPhiNodes() const
+{
+    GenTree* firstNonPhiNode = FirstNonPhiNode();
+    if (firstNonPhiNode == nullptr)
+    {
+        return ReadOnlyRange();
+    }
+
+    return ReadOnlyRange(firstNonPhiNode, m_lastNode);
 }
 
 //------------------------------------------------------------------------
@@ -578,15 +547,14 @@ void LIR::Range::InsertBefore(GenTree* node, GenTree* insertionPoint)
 
     if (insertionPoint == nullptr)
     {
-        assert(FirstNode() == nullptr);
-        assert(LastNode() == nullptr);
+        assert(IsEmpty());
 
-        FirstNode() = node;
-        LastNode() = node;
+        m_firstNode = node;
+        m_lastNode = node;
         return;
     }
 
-    assert(ContainsNode(insertionPoint));
+    assert(Contains(insertionPoint));
 
     node->gtPrev = insertionPoint->gtPrev;
     if (node->gtPrev != nullptr)
@@ -595,8 +563,8 @@ void LIR::Range::InsertBefore(GenTree* node, GenTree* insertionPoint)
     }
     else
     {
-        assert(insertionPoint == FirstNode());
-        FirstNode() = node;
+        assert(insertionPoint == m_firstNode);
+        m_firstNode = node;
     }
 
     node->gtNext = insertionPoint;
@@ -623,15 +591,14 @@ void LIR::Range::InsertAfter(GenTree* node, GenTree* insertionPoint)
 
     if (insertionPoint == nullptr)
     {
-        assert(FirstNode() == nullptr);
-        assert(LastNode() == nullptr);
+        assert(IsEmpty());
 
-        FirstNode() = node;
-        LastNode() = node;
+        m_firstNode = node;
+        m_lastNode = node;
         return;
     }
 
-    assert(ContainsNode(insertionPoint));
+    assert(Contains(insertionPoint));
 
     node->gtNext = insertionPoint->gtNext;
     if (node->gtNext != nullptr)
@@ -640,8 +607,8 @@ void LIR::Range::InsertAfter(GenTree* node, GenTree* insertionPoint)
     }
     else
     {
-        assert(insertionPoint == LastNode());
-        LastNode() = node;
+        assert(insertionPoint == m_lastNode);
+        m_lastNode = node;
     }
 
     node->gtPrev = insertionPoint;
@@ -660,36 +627,34 @@ void LIR::Range::InsertAfter(GenTree* node, GenTree* insertionPoint)
 //                     the contents of `this` range will be set to those of
 //                     `range`.
 //
-void LIR::Range::InsertBefore(const Range& range, GenTree* insertionPoint)
+void LIR::Range::InsertBefore(Range&& range, GenTree* insertionPoint)
 {
     assert(!range.IsEmpty());
-    assert(!range.IsSubRange());
 
     if (insertionPoint == nullptr)
     {
-        assert(FirstNode() == nullptr);
-        assert(LastNode() == nullptr);
+        assert(IsEmpty());
 
-        FirstNode() = range.FirstNode();
-        LastNode() = range.LastNode();
+        m_firstNode = range.m_firstNode;
+        m_lastNode = range.m_lastNode;
         return;
     }
 
-    assert(ContainsNode(insertionPoint));
+    assert(Contains(insertionPoint));
 
     if (insertionPoint->gtPrev == nullptr)
     {
-        assert(insertionPoint == FirstNode());
-        FirstNode() = range.FirstNode();
+        assert(insertionPoint == m_firstNode);
+        m_firstNode = range.m_firstNode;
     }
     else
     {
-        range.FirstNode()->gtPrev = insertionPoint->gtPrev;
-        range.FirstNode()->gtPrev->gtNext = range.FirstNode();
+        range.m_firstNode->gtPrev = insertionPoint->gtPrev;
+        range.m_firstNode->gtPrev->gtNext = range.m_firstNode;
     }
 
-    range.LastNode()->gtNext = insertionPoint;
-    insertionPoint->gtPrev = range.LastNode();
+    range.m_lastNode->gtNext = insertionPoint;
+    insertionPoint->gtPrev = range.m_lastNode;
 }
 
 //------------------------------------------------------------------------
@@ -704,36 +669,35 @@ void LIR::Range::InsertBefore(const Range& range, GenTree* insertionPoint)
 //                     the contents of `this` range will be set to those of
 //                     `range`.
 //
-void LIR::Range::InsertAfter(const Range& range, GenTree* insertionPoint)
+void LIR::Range::InsertAfter(Range&& range, GenTree* insertionPoint)
 {
     assert(!range.IsEmpty());
-    assert(!range.IsSubRange());
 
     if (insertionPoint == nullptr)
     {
-        assert(FirstNode() == nullptr);
-        assert(LastNode() == nullptr);
+        assert(m_firstNode == nullptr);
+        assert(m_lastNode == nullptr);
 
-        FirstNode() = range.FirstNode();
-        LastNode() = range.LastNode();
+        m_firstNode = range.m_firstNode;
+        m_lastNode = range.m_lastNode;
         return;
     }
 
-    assert(ContainsNode(insertionPoint));
+    assert(Contains(insertionPoint));
 
     if (insertionPoint->gtNext == nullptr)
     {
-        assert(insertionPoint == LastNode());
-        LastNode() = range.LastNode();
+        assert(insertionPoint == m_lastNode);
+        m_lastNode = range.m_lastNode;
     }
     else
     {
-        range.LastNode()->gtNext = insertionPoint->gtNext;
-        range.LastNode()->gtNext->gtPrev = range.LastNode();
+        range.m_lastNode->gtNext = insertionPoint->gtNext;
+        range.m_lastNode->gtNext->gtPrev = range.m_lastNode;
     }
 
-    range.FirstNode()->gtPrev = insertionPoint;
-    insertionPoint->gtNext = range.FirstNode();
+    range.m_firstNode->gtPrev = insertionPoint;
+    insertionPoint->gtNext = range.m_firstNode;
 }
 
 //------------------------------------------------------------------------
@@ -744,7 +708,7 @@ void LIR::Range::InsertAfter(const Range& range, GenTree* insertionPoint)
 //
 void LIR::Range::InsertAtBeginning(GenTree* node)
 {
-    InsertBefore(node, FirstNode());
+    InsertBefore(node, m_firstNode);
 }
 
 //------------------------------------------------------------------------
@@ -755,7 +719,7 @@ void LIR::Range::InsertAtBeginning(GenTree* node)
 //
 void LIR::Range::InsertAtEnd(GenTree* node)
 {
-    InsertAfter(node, LastNode());
+    InsertAfter(node, m_lastNode);
 }
 
 //------------------------------------------------------------------------
@@ -764,9 +728,9 @@ void LIR::Range::InsertAtEnd(GenTree* node)
 // Arguments:
 //    range - The range to splice in.
 //
-void LIR::Range::InsertAtBeginning(const Range& range)
+void LIR::Range::InsertAtBeginning(Range&& range)
 {
-    InsertBefore(range, FirstNode());
+    InsertBefore(std::move(range), m_firstNode);
 }
 
 //------------------------------------------------------------------------
@@ -775,9 +739,9 @@ void LIR::Range::InsertAtBeginning(const Range& range)
 // Arguments:
 //    range - The range to splice in.
 //
-void LIR::Range::InsertAtEnd(const Range& range)
+void LIR::Range::InsertAtEnd(Range&& range)
 {
-    InsertAfter(range, LastNode());
+    InsertAfter(std::move(range), m_lastNode);
 }
 
 
@@ -790,7 +754,7 @@ void LIR::Range::InsertAtEnd(const Range& range)
 void LIR::Range::Remove(GenTree* node)
 {
     assert(node != nullptr);
-    assert(ContainsNode(node));
+    assert(Contains(node));
 
     GenTree* prev = node->gtPrev;
     GenTree* next = node->gtNext;
@@ -801,8 +765,8 @@ void LIR::Range::Remove(GenTree* node)
     }
     else
     {
-        assert(node == FirstNode());
-        FirstNode() = next;
+        assert(node == m_firstNode);
+        m_firstNode = next;
     }
 
     if (next != nullptr)
@@ -811,8 +775,8 @@ void LIR::Range::Remove(GenTree* node)
     }
     else
     {
-        assert(node == LastNode());
-        LastNode() = prev;
+        assert(node == m_lastNode);
+        m_lastNode = prev;
     }
 
     node->gtPrev = nullptr;
@@ -822,16 +786,24 @@ void LIR::Range::Remove(GenTree* node)
 //------------------------------------------------------------------------
 // LIR::Range::Remove: Removes a subrange from this range.
 //
-// Arguments:
-//    range - The subrange to remove. Must be part of this range.
+// Both the start and the end of the subrange must be part of this range.
 //
-void LIR::Range::Remove(const Range& range)
+// Arguments:
+//    firstNode - The first node in the subrange.
+//    lastNode - The last node in the subrange.
+//
+// Returns:
+//    A mutable range containing the removed nodes.
+//
+LIR::Range LIR::Range::Remove(GenTree* firstNode, GenTree* lastNode)
 {
-    assert(!range.IsEmpty());
-    assert(ContainsNode(range.FirstNode()));
+    assert(firstNode != nullptr);
+    assert(lastNode != nullptr);
+    assert(Contains(firstNode));
+    assert((firstNode == lastNode) || firstNode->Precedes(lastNode));
 
-    GenTree* prev = range.FirstNode()->gtPrev;
-    GenTree* next = range.LastNode()->gtNext;
+    GenTree* prev = firstNode->gtPrev;
+    GenTree* next = lastNode->gtNext;
 
     if (prev != nullptr)
     {
@@ -839,8 +811,8 @@ void LIR::Range::Remove(const Range& range)
     }
     else
     {
-        assert(range.FirstNode() == FirstNode());
-        FirstNode() = next;
+        assert(firstNode == m_firstNode);
+        m_firstNode = next;
     }
 
     if (next != nullptr)
@@ -849,12 +821,28 @@ void LIR::Range::Remove(const Range& range)
     }
     else
     {
-        assert(range.LastNode() == LastNode());
-        LastNode() = prev;
+        assert(lastNode == m_lastNode);
+        m_lastNode = prev;
     }
 
-    range.FirstNode()->gtPrev = nullptr;
-    range.LastNode()->gtNext = nullptr;
+    firstNode->gtPrev = nullptr;
+    lastNode->gtNext = nullptr;
+
+    return Range(firstNode, lastNode);
+}
+
+//------------------------------------------------------------------------
+// LIR::Range::Remove: Removes a subrange from this range.
+//
+// Arguments:
+//    range - The subrange to remove. Must be part of this range.
+//
+// Returns:
+//    A mutable range containing the removed nodes.
+//
+LIR::Range LIR::Range::Remove(ReadOnlyRange&& range)
+{
+    return Remove(range.m_firstNode, range.m_lastNode);
 }
 
 //------------------------------------------------------------------------
@@ -871,14 +859,14 @@ bool LIR::Range::TryGetUse(GenTree* node, Use* use)
 {
     assert(node != nullptr);
     assert(use != nullptr);
-    assert(ContainsNode(node));
+    assert(Contains(node));
 
     // Don't bother looking for uses of nodes that are not values.
     // If the node is the last node, we won't find a use (and we would
     // end up creating an illegal range if we tried).
-    if (node->IsValue() && (node != EndExclusive()))
+    if (node->IsValue() && (node != LastNode()))
     {
-        for (GenTree* n : LIR::AsRange(node->gtNext, EndExclusive()))
+        for (GenTree* n : ReadOnlyRange(node->gtNext, m_lastNode))
         {
             GenTree** edge;
             if (n->TryGetUse(node, &edge))
@@ -935,7 +923,7 @@ bool LIR::Range::TryGetUse(GenTree* node, Use* use)
 // Returns:
 //    The computed subrange.
 //
-LIR::Range LIR::Range::GetMarkedRange(unsigned markCount, GenTree* start, bool* isClosed, unsigned* sideEffects) const
+LIR::ReadOnlyRange LIR::Range::GetMarkedRange(unsigned markCount, GenTree* start, bool* isClosed, unsigned* sideEffects) const
 {
     assert(markCount != 0);
     assert(start != nullptr);
@@ -1001,10 +989,23 @@ LIR::Range LIR::Range::GetMarkedRange(unsigned markCount, GenTree* start, bool* 
 
     *isClosed = !sawUnmarkedNode;
     *sideEffects = sideEffectsInRange;
-    return LIR::Range(firstNode, lastNode);
+    return ReadOnlyRange(firstNode, lastNode);
 }
 
-LIR::Range LIR::Range::GetTreeRange(GenTree* root, bool* isClosed) const
+//------------------------------------------------------------------------
+// LIR::Range::GetTreeRange: Computes the subrange that includes all nodes
+//                           in the dataflow tree rooted at a particular
+//                           node.
+//
+// Arguments:
+//    root        - The root of the dataflow tree.
+//    isClosed    - An output parameter that is set to true if the returned
+//                  range contains only nodes in the dataflow tree and false
+//                  otherwise.
+//
+// Returns:
+//    The computed subrange.
+LIR::ReadOnlyRange LIR::Range::GetTreeRange(GenTree* root, bool* isClosed) const
 {
     unsigned unused;
     return GetTreeRange(root, isClosed, &unused);
@@ -1025,7 +1026,7 @@ LIR::Range LIR::Range::GetTreeRange(GenTree* root, bool* isClosed) const
 //
 // Returns:
 //    The computed subrange.
-LIR::Range LIR::Range::GetTreeRange(GenTree* root, bool* isClosed, unsigned* sideEffects) const
+LIR::ReadOnlyRange LIR::Range::GetTreeRange(GenTree* root, bool* isClosed, unsigned* sideEffects) const
 {
     assert(root != nullptr);
 
@@ -1036,7 +1037,23 @@ LIR::Range LIR::Range::GetTreeRange(GenTree* root, bool* isClosed, unsigned* sid
     return GetMarkedRange(markCount, root, isClosed, sideEffects);
 }
 
-LIR::Range LIR::Range::GetRangeOfOperandTrees(GenTree* root, bool* isClosed, unsigned* sideEffects) const
+//------------------------------------------------------------------------
+// LIR::Range::GetTreeRange: Computes the subrange that includes all nodes
+//                           in the dataflow trees rooted by the operands
+//                           to a particular node.
+//
+// Arguments:
+//    root        - The root of the dataflow tree.
+//    isClosed    - An output parameter that is set to true if the returned
+//                  range contains only nodes in the dataflow tree and false
+//                  otherwise.
+//    sideEffects - An output parameter that summarizes the side effects
+//                  contained in the returned range.
+//
+// Returns:
+//    The computed subrange.
+//
+LIR::ReadOnlyRange LIR::Range::GetRangeOfOperandTrees(GenTree* root, bool* isClosed, unsigned* sideEffects) const
 {
     assert(root != nullptr);
     assert(isClosed != nullptr);
@@ -1054,46 +1071,13 @@ LIR::Range LIR::Range::GetRangeOfOperandTrees(GenTree* root, bool* isClosed, uns
     {
         *isClosed = true;
         *sideEffects = 0;
-        return LIR::EmptyRange();
+        return ReadOnlyRange();
     }
 
     return GetMarkedRange(markCount, root, isClosed, sideEffects);
 }
 
 #ifdef DEBUG
-
-//------------------------------------------------------------------------
-// LIR::Range::ContainsNode: Indicates whether or not this range contains
-//                           a given node.
-//
-// Arguments:
-//    node - The node to find.
-//
-// Return Value: True if this range contains the given node; false
-//               otherwise.
-//
-bool LIR::Range::ContainsNode(GenTree* node) const
-{
-    assert(node != nullptr);
-
-    // TODO(pdg): derive this from the # of nodes in the function as well as
-    // the debug level. Checking small functions is pretty cheap; checking
-    // large functions is not.
-    if (JitConfig.JitExpensiveDebugCheckLevel() < 2)
-    {
-        return true;
-    }
-
-    for (GenTree* n : *this)
-    {
-        if (n == node)
-        {
-            return true;
-        }
-    }
-
-    return false;
-}
 
 //------------------------------------------------------------------------
 // LIR::Range::CheckLIR: Performs a set of correctness checks on the LIR
@@ -1120,13 +1104,6 @@ bool LIR::Range::ContainsNode(GenTree* node) const
 //
 bool LIR::Range::CheckLIR(Compiler* compiler, bool checkUnusedValues) const
 {
-    // Make sure the range itself is valid.
-    assert(IsValid());
-
-    // The check that uses are correctly linked into this range may fail
-    // erroneously if this range is a sub-range.
-    assert(!IsSubRange());
-
     if (IsEmpty())
     {
         // Nothing more to check.
@@ -1138,7 +1115,7 @@ bool LIR::Range::CheckLIR(Compiler* compiler, bool checkUnusedValues) const
     //
     // To detect circularity, use the "tortoise and hare" 2-pointer algorithm.
 
-    GenTree* slowNode = Begin();
+    GenTree* slowNode = FirstNode();
     assert(slowNode != nullptr);    // because it's a non-empty range
     GenTree* fastNode1 = nullptr;
     GenTree* fastNode2 = slowNode;
@@ -1242,7 +1219,7 @@ bool LIR::Range::CheckLIR(Compiler* compiler, bool checkUnusedValues) const
         }
     }
 
-    assert(prev == LastNode());
+    assert(prev == m_lastNode);
 
     // At this point the unusedDefs map should contain only unused values.
     if (checkUnusedValues)
@@ -1260,38 +1237,20 @@ bool LIR::Range::CheckLIR(Compiler* compiler, bool checkUnusedValues) const
 #endif // DEBUG
 
 //------------------------------------------------------------------------
+// LIR::AsRange: Returns an LIR view of the given basic block.
+//
+LIR::Range& LIR::AsRange(BasicBlock* block)
+{
+    return *static_cast<Range*>(block);
+}
+
+//------------------------------------------------------------------------
 // LIR::EmptyRange: Constructs and returns an empty range.
 //
 // static
 LIR::Range LIR::EmptyRange()
 {
-    return Range(static_cast<GenTree*>(nullptr), static_cast<GenTree*>(nullptr));
-}
-
-//------------------------------------------------------------------------
-// LIR::AsRange: Constructs and returns a range given a first and last
-//               node.
-//
-// Arguments:
-//    firstNode - The first node in the range. Must precede lastNode.
-//    lastNode - The last node in the range. Must follow firstNode.
-//
-// static
-LIR::Range LIR::AsRange(GenTree* firstNode, GenTree* lastNode)
-{
-    return Range(firstNode, lastNode);
-}
-
-//------------------------------------------------------------------------
-// LIR::AsRange: Constructs and returns a range given a sequenced HIR tree.
-//
-// Arguments:
-//    tree - The sequenced HIR tree.
-//
-// static
-LIR::Range LIR::AsRange(Compiler* compiler, GenTree* tree)
-{
-    return Range(compiler->fgGetFirstNode(tree), tree);
+    return Range(nullptr, nullptr);
 }
 
 //------------------------------------------------------------------------
@@ -1309,12 +1268,16 @@ LIR::Range LIR::AsRange(Compiler* compiler, GenTree* tree)
 // static
 LIR::Range LIR::SeqTree(Compiler* compiler, GenTree* tree)
 {
+    // TODO(pdg): it would be great to assert that the node has not already been
+    // threaded into an order, but I'm not sure that will be practical at this
+    // point.
+
     compiler->gtSetEvalOrder(tree);
-    return AsRange(compiler->fgSetTreeSeq(tree, nullptr, true), tree);
+    return Range(compiler->fgSetTreeSeq(tree, nullptr, true), tree);
 }
 
-// TODO(pdg): this should probably just be folded into LIR::Range::Remove(const Range& range);
-void LIR::DecRefCnts(Compiler* compiler, BasicBlock* block, const Range& range)
+// TODO(pdg): this should probably just be folded into LIR::Range::Remove(ReadOnlyRange& range);
+void LIR::DecRefCnts(Compiler* compiler, BasicBlock* block, const ReadOnlyRange& range)
 {
     for (GenTree* node : range)
     {

--- a/src/jit/lir.h
+++ b/src/jit/lir.h
@@ -7,6 +7,7 @@
 
 class Compiler;
 struct GenTree;
+struct BasicBlock;
 
 class LIR final
 {
@@ -72,36 +73,25 @@ public:
         unsigned ReplaceWithLclVar(Compiler* compiler, unsigned blockWeight, unsigned lclNum = BAD_VAR_NUM);
     };
 
-    //------------------------------------------------------------------------
-    // LIR::Range: Represents a contiguous range of LIR nodes. Provides a
-    //             variety of utilites that modify the LIR contained in the
-    //             range.
-    //
-    class Range
+    class ReadOnlyRange
     {
         friend class LIR;
-        friend class SimpleRange;
+        friend class Range;
+        friend struct BasicBlock;
 
     private:
-        GenTree** m_firstNodeSlot;
-        GenTree** m_lastNodeSlot;
-        bool m_isSimpleRange;      // A simple range provides its own storage: instead of holding
-                                   // pointers to the first and last node tracked by some other
-                                   // container, `m_firstNodeSlot` and `m_lastNodeSlot` hold pointers
-                                   // to the first and last node in the range, respectively.
+        GenTree* m_firstNode;
+        GenTree* m_lastNode;
 
-        Range(GenTree** firstNodeSlot, GenTree** lastNodeSlot);
-        Range(GenTree* firstNode, GenTree* lastNode);
+        ReadOnlyRange(GenTree* firstNode, GenTree* lastNode);
 
-        GenTree*& FirstNode() const;
-        GenTree*& LastNode() const;
-
-        Range GetMarkedRange(unsigned markCount, GenTree* start, bool* isClosed, unsigned* sideEffects) const;
+        ReadOnlyRange(const ReadOnlyRange& other) = delete;
+        ReadOnlyRange& operator=(const ReadOnlyRange& other) = delete;
 
     public:
         class Iterator
         {
-            friend class Range;
+            friend class ReadOnlyRange;
 
             GenTree* m_node;
 
@@ -145,7 +135,7 @@ public:
 
         class ReverseIterator
         {
-            friend class Range;
+            friend class ReadOnlyRange;
 
             GenTree* m_node;
 
@@ -186,12 +176,14 @@ public:
                 return *this;
             }
         };
+ 
+        ReadOnlyRange();
+        ReadOnlyRange(ReadOnlyRange&& other);
 
-        Range();
+        GenTree* FirstNode() const;
+        GenTree* LastNode() const;
 
-        GenTree* Begin() const;
-        GenTree* End() const;
-        GenTree* EndExclusive() const;
+        bool IsEmpty() const;
 
         Iterator begin() const;
         Iterator end() const;
@@ -199,79 +191,72 @@ public:
         ReverseIterator rbegin() const;
         ReverseIterator rend() const;
 
-        bool IsValid() const;
-        bool IsEmpty() const;
-        bool IsSubRange() const;
+#ifdef DEBUG
+        bool Contains(GenTree* node) const;
+#endif
+    };
+
+    //------------------------------------------------------------------------
+    // LIR::Range: Represents a contiguous range of LIR nodes. Provides a
+    //             variety of utilites that modify the LIR contained in the
+    //             range.
+    //
+    class Range : public ReadOnlyRange
+    {
+        friend class LIR;
+        friend struct BasicBlock;
+
+    private:
+        Range(GenTree* firstNode, GenTree* lastNode);
+
+        Range(const Range& other) = delete;
+        Range& operator=(const Range& other) = delete;
+
+        ReadOnlyRange GetMarkedRange(unsigned markCount, GenTree* start, bool* isClosed, unsigned* sideEffects) const;
+
+    public:
+        Range();
+        Range(Range&& other);
 
         GenTree* FirstNonPhiNode() const;
         GenTree* FirstNonPhiOrCatchArgNode() const;
 
+        ReadOnlyRange PhiNodes() const;
+        ReadOnlyRange NonPhiNodes() const;
+
         void InsertBefore(GenTree* node, GenTree* insertionPoint);
         void InsertAfter(GenTree* node, GenTree* insertionPoint);
 
-        void InsertBefore(const Range& range, GenTree* insertionPoint);
-        void InsertAfter(const Range& range, GenTree* insertionPoint);
+        void InsertBefore(Range&& range, GenTree* insertionPoint);
+        void InsertAfter(Range&& range, GenTree* insertionPoint);
 
         void InsertAtBeginning(GenTree* node);
         void InsertAtEnd(GenTree* node);
 
-        void InsertAtBeginning(const Range& range);
-        void InsertAtEnd(const Range& range);
+        void InsertAtBeginning(Range&& range);
+        void InsertAtEnd(Range&& range);
 
         void Remove(GenTree* node);
-        void Remove(const Range& range);
+        Range Remove(GenTree* firstNode, GenTree* lastNode);
+        Range Remove(ReadOnlyRange&& range);
 
         bool TryGetUse(GenTree* node, Use* use);
 
-        Range GetTreeRange(GenTree* root, bool* isClosed) const;
-        Range GetTreeRange(GenTree* root, bool* isClosed, unsigned* sideEffects) const;
-        Range GetRangeOfOperandTrees(GenTree* root, bool* isClosed, unsigned* sideEffects) const;
+        ReadOnlyRange GetTreeRange(GenTree* root, bool* isClosed) const;
+        ReadOnlyRange GetTreeRange(GenTree* root, bool* isClosed, unsigned* sideEffects) const;
+        ReadOnlyRange GetRangeOfOperandTrees(GenTree* root, bool* isClosed, unsigned* sideEffects) const;
 
 #ifdef DEBUG
-        bool ContainsNode(GenTree* node) const;
         bool CheckLIR(Compiler* compiler, bool checkUnusedValues = false) const;
 #endif
     };
 
 public:
+    static Range& AsRange(BasicBlock* block);
+
     static Range EmptyRange();
-    static Range AsRange(GenTree* firstNode, GenTree* lastNode);
-    static Range AsRange(Compiler* compiler, GenTree* tree);
     static Range SeqTree(Compiler* compiler, GenTree* tree);
-    static void DecRefCnts(Compiler* compiler, BasicBlock* block, const Range& range);
-
-    //------------------------------------------------------------------------
-    // LIR::AsRange: Constructs and returns an LIR::Range value given a value
-    //               of a type that provides the storage for the first and
-    //               last nodes of the range.
-    //
-    // TContainer must implement the folliwing methods:
-    //    GenTree** TContainer::FirstLIRNodeSlot();
-    //    GenTree** TContainer::LastLIRNodeSlot();
-    //
-    // Arguments:
-    //    container - The value that will provide the storage for the range's
-    //                first and last nodes.
-    //
-    // Return Value: The newly constructed range.
-    //
-    template<typename TContainer>
-    static Range AsRange(TContainer& container)
-    {
-        return Range(container->FirstLIRNodeSlot(), container->LastLIRNodeSlot());
-    }
-
-    //------------------------------------------------------------------------
-    // LIR::AsRange: See the overload of AsRange() above. This overload
-    //               accepts a pointer-typed argument so that the `this`
-    //               parameter of a calling member method can be provided as
-    //               the argument to `container`.
-    //
-    template<typename TContainer>
-    static Range AsRange(TContainer* container)
-    {
-        return Range(container->FirstLIRNodeSlot(), container->LastLIRNodeSlot());
-    }
+    static void DecRefCnts(Compiler* compiler, BasicBlock* block, const ReadOnlyRange& range);
 };
 
 #endif // _LIR_H_

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1805,10 +1805,10 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree *callTarget
     assert(argEntry->node->gtOper == GT_PUTARG_STK);
     GenTree* arg0 = argEntry->node->gtOp.gtOp1;
 
-    BlockRange().InsertAfter(callTargetRange, arg0);
+    BlockRange().InsertAfter(std::move(callTargetRange), arg0);
 
     bool isClosed;
-    LIR::Range secondArgRange = BlockRange().GetTreeRange(arg0, &isClosed);
+    LIR::ReadOnlyRange secondArgRange = BlockRange().GetTreeRange(arg0, &isClosed);
     assert(isClosed);
     
     argEntry->node->gtOp.gtOp1 = callTarget;

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -92,10 +92,8 @@ bool Lowering::IsSafeToContainMem(GenTree* parentNode, GenTree* childNode)
 
     unsigned int childFlags = (childNode->gtFlags & GTF_ALL_EFFECT);
 
-    LIR::Range range = LIR::AsRange(childNode, parentNode);
     GenTree* node;
-    GenTree* end;
-    for (node = range.Begin(), end = range.EndExclusive(); node != end; node = node->gtNext)
+    for (node = childNode; node != parentNode; node = node->gtNext)
     {
         assert(node != nullptr);
 
@@ -113,7 +111,6 @@ bool Lowering::IsSafeToContainMem(GenTree* parentNode, GenTree* childNode)
         }
     }
 
-    assert(node == parentNode);
     return true;
 }
 
@@ -126,7 +123,7 @@ GenTree* Lowering::LowerNode(GenTree* node)
     switch (node->gtOper)
     {
     case GT_IND:
-        TryCreateAddrMode(LIR::Use(m_blockRange, &node->gtOp.gtOp1, node), true);
+        TryCreateAddrMode(LIR::Use(BlockRange(), &node->gtOp.gtOp1, node), true);
         break;
 
     case GT_STOREIND:
@@ -303,7 +300,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
     // To avoid confusion, we'll alias m_block to originalSwitchBB
     // that represents the node we're morphing.
     BasicBlock* originalSwitchBB = m_block;
-    LIR::Range switchBBRange = LIR::AsRange(originalSwitchBB);
+    LIR::Range& switchBBRange = LIR::AsRange(originalSwitchBB);
 
     // jumpCnt is the number of elements in the jump table array.
     // jumpTab is the actual pointer to the jump table array.
@@ -424,12 +421,9 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
     gtDefaultCaseJump->gtFlags = node->gtFlags;
 
     LIR::Range condRange = LIR::SeqTree(comp, gtDefaultCaseJump);
-    switchBBRange.InsertAtEnd(condRange);
+    switchBBRange.InsertAtEnd(std::move(condRange));
 
-    //TODO(btf): we can't use fgSplitBlockAfterStatement/condStmt -- no statements left.
-    // TODO-LIR: I really just want to use LastNode(), but that's private. 'EndExclusive' doesn't quite have the same
-    // ring to it, but gives the right answer.
-    BasicBlock* afterDefaultCondBlock = comp->fgSplitBlockAfterNode(originalSwitchBB, condRange.EndExclusive());
+    BasicBlock* afterDefaultCondBlock = comp->fgSplitBlockAfterNode(originalSwitchBB, condRange.LastNode());
 
     // afterDefaultCondBlock is now the switch, and all the switch targets have it as a predecessor.
     // originalSwitchBB is now a BBJ_NONE, and there is a predecessor edge in afterDefaultCondBlock
@@ -514,7 +508,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
         // we'll delete it.
         bool fUsedAfterDefaultCondBlock = false;
         BasicBlock* currentBlock = afterDefaultCondBlock;
-        LIR::Range currentBBRange = LIR::AsRange(currentBlock);
+        LIR::Range* currentBBRange = &LIR::AsRange(currentBlock);
 
         // Walk to entries 0 to jumpCnt - 1. If a case target follows, ignore it and let it fall through.
         // If no case target follows, the last one doesn't need to be a compare/branch: it can be an
@@ -542,7 +536,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
                 BasicBlock* newBlock = comp->fgNewBBafter(BBJ_NONE, currentBlock, true);
                 comp->fgAddRefPred(newBlock, currentBlock); // The fall-through predecessor.
                 currentBlock = newBlock;
-                currentBBRange = LIR::AsRange(currentBlock);
+                currentBBRange = &LIR::AsRange(currentBlock);
             }
             else
             {
@@ -587,7 +581,7 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
 
                 GenTreePtr gtCaseBranch = comp->gtNewOperNode(GT_JTRUE, TYP_VOID, gtCaseCond);
                 LIR::Range caseRange = LIR::SeqTree(comp, gtCaseBranch);
-                currentBBRange.InsertAtEnd(condRange);
+                currentBBRange->InsertAtEnd(std::move(condRange));
             }
         }
 
@@ -638,9 +632,8 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
         afterDefaultCondBlock->bbJumpSwt->removeDefault();
         comp->fgInvalidateSwitchDescMapEntry(afterDefaultCondBlock);
 
-        LIR::Range afterDefaultCondBBRange = LIR::AsRange(afterDefaultCondBlock);
-        LIR::Range tableSwitchRange = LIR::SeqTree(comp, gtTableSwitch);
-        afterDefaultCondBBRange.InsertAtEnd(tableSwitchRange);
+        LIR::Range& afterDefaultCondBBRange = LIR::AsRange(afterDefaultCondBlock);
+        afterDefaultCondBBRange.InsertAtEnd(LIR::SeqTree(comp, gtTableSwitch));
     }
 
     GenTree* next = node->gtNext;
@@ -668,7 +661,7 @@ void Lowering::ReplaceArgWithPutArgOrCopy(GenTree** argSlot, GenTree* putArgOrCo
     putArgOrCopy->gtOp.gtOp1 = arg;
 
     // Insert the putarg/copy into the block
-    m_blockRange.InsertAfter(putArgOrCopy, arg);
+    BlockRange().InsertAfter(putArgOrCopy, arg);
 }
 
 //------------------------------------------------------------------------
@@ -1216,7 +1209,7 @@ void Lowering::LowerCall(GenTree* node)
         }
     }
 
-    assert(m_blockRange.CheckLIR(comp));
+    assert(BlockRange().CheckLIR(comp));
     
     if (call->IsTailCallViaHelper())
     {
@@ -1255,29 +1248,29 @@ void Lowering::LowerCall(GenTree* node)
                 if (call->gtCallCookie != nullptr)
                 {
 #ifdef DEBUG
-                    GenTree* firstCallAddrNode = m_blockRange.GetTreeRange(call->gtCallAddr, &isClosed).Begin();
+                    GenTree* firstCallAddrNode = BlockRange().GetTreeRange(call->gtCallAddr, &isClosed).FirstNode();
                     assert(isClosed);
                     assert(call->gtCallCookie->Precedes(firstCallAddrNode));
 #endif // DEBUG
 
-                    insertionPoint = m_blockRange.GetTreeRange(call->gtCallCookie, &isClosed).Begin();
+                    insertionPoint = BlockRange().GetTreeRange(call->gtCallCookie, &isClosed).FirstNode();
                 }
                 else if (call->gtCallAddr != nullptr)
                 {
-                    insertionPoint = m_blockRange.GetTreeRange(call->gtCallAddr, &isClosed).Begin();
+                    insertionPoint = BlockRange().GetTreeRange(call->gtCallAddr, &isClosed).FirstNode();
                 }
 
                 assert(isClosed);
             }
         }
 
-        m_blockRange.InsertBefore(resultRange, insertionPoint);
+        BlockRange().InsertBefore(std::move(resultRange), insertionPoint);
 
         call->gtControlExpr = result;
     }
 #endif //!_TARGET_ARM_
 
-    assert(m_blockRange.CheckLIR(comp));
+    assert(BlockRange().CheckLIR(comp));
 
     if (comp->opts.IsJit64Compat())
     {
@@ -1473,7 +1466,7 @@ void  Lowering::InsertProfTailCallHook(GenTreeCall* call, GenTree *insertionPoin
 
     assert(insertionPoint != nullptr);
     GenTreePtr profHookNode = new (comp, GT_PROF_HOOK) GenTree(GT_PROF_HOOK, TYP_VOID);
-    m_blockRange.InsertBefore(profHookNode, insertionPoint);
+    BlockRange().InsertBefore(profHookNode, insertionPoint);
 }
 
 // Lower fast tail call implemented as epilog+jmp.
@@ -1646,7 +1639,7 @@ void Lowering::LowerFastTailCall(GenTreeCall *call)
             assert(tmpType != TYP_UNDEF);
             GenTreeLclVar* local = new(comp, GT_LCL_VAR) GenTreeLclVar(GT_LCL_VAR, tmpType, callerArgLclNum, BAD_IL_OFFSET);
             GenTree* assignExpr = comp->gtNewTempAssign(tmpLclNum, local);
-            m_blockRange.InsertBefore(LIR::SeqTree(comp, assignExpr), firstPutArgStk);
+            BlockRange().InsertBefore(LIR::SeqTree(comp, assignExpr), firstPutArgStk);
         }
     }
 
@@ -1657,7 +1650,7 @@ void Lowering::LowerFastTailCall(GenTreeCall *call)
     if (firstPutArgStk != nullptr)
     {                
         startNonGCNode = new (comp, GT_START_NONGC) GenTree(GT_START_NONGC, TYP_VOID);
-        m_blockRange.InsertBefore(startNonGCNode, firstPutArgStk);
+        BlockRange().InsertBefore(startNonGCNode, firstPutArgStk);
 
         // Gc-interruptability in the following case:
         //     foo(a, b, c, d, e) { bar(a, b, c, d, e); } 
@@ -1673,7 +1666,7 @@ void Lowering::LowerFastTailCall(GenTreeCall *call)
         {
             assert(comp->fgFirstBB == comp->compCurBB);
             GenTreePtr noOp = new (comp, GT_NO_OP) GenTree(GT_NO_OP, TYP_VOID);
-            m_blockRange.InsertBefore(noOp, startNonGCNode);
+            BlockRange().InsertBefore(noOp, startNonGCNode);
         }
     }
 
@@ -1755,10 +1748,10 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree *callTarget
         assert(call->gtCallAddr != nullptr);
 
         bool isClosed;
-        LIR::Range callAddrRange = m_blockRange.GetTreeRange(call->gtCallAddr, &isClosed);
+        LIR::ReadOnlyRange callAddrRange = BlockRange().GetTreeRange(call->gtCallAddr, &isClosed);
         assert(isClosed);
 
-        m_blockRange.Remove(callAddrRange);
+        BlockRange().Remove(std::move(callAddrRange));
     }
 
     // The callTarget tree needs to be sequenced.
@@ -1784,13 +1777,13 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree *callTarget
     assert(argEntry->node->gtOper == GT_PUTARG_REG);
     GenTree *secondArg = argEntry->node->gtOp.gtOp1;
 
-    m_blockRange.InsertAfter(callTargetRange, secondArg);
+    BlockRange().InsertAfter(std::move(callTargetRange), secondArg);
 
     bool isClosed;
-    LIR::Range secondArgRange = m_blockRange.GetTreeRange(secondArg, &isClosed);
+    LIR::ReadOnlyRange secondArgRange = BlockRange().GetTreeRange(secondArg, &isClosed);
     assert(isClosed);
 
-    m_blockRange.Remove(secondArgRange);
+    BlockRange().Remove(std::move(secondArgRange));
 
     argEntry->node->gtOp.gtOp1 = callTarget;
 
@@ -1812,10 +1805,10 @@ GenTree* Lowering::LowerTailCallViaHelper(GenTreeCall* call, GenTree *callTarget
     assert(argEntry->node->gtOper == GT_PUTARG_STK);
     GenTree* arg0 = argEntry->node->gtOp.gtOp1;
 
-    m_blockRange.InsertAfter(callTargetRange, arg0);
+    BlockRange().InsertAfter(callTargetRange, arg0);
 
     bool isClosed;
-    LIR::Range secondArgRange = m_blockRange.GetTreeRange(arg0, &isClosed);
+    LIR::Range secondArgRange = BlockRange().GetTreeRange(arg0, &isClosed);
     assert(isClosed);
     
     argEntry->node->gtOp.gtOp1 = callTarget;
@@ -2079,7 +2072,7 @@ GenTree* Lowering::LowerDelegateInvoke(GenTreeCall* call)
     {
         unsigned delegateInvokeTmp = comp->lvaGrabTemp(true DEBUGARG("delegate invoke call"));
 
-        LIR::Use thisExprUse(m_blockRange, &thisArgNode->gtOp.gtOp1, thisArgNode);
+        LIR::Use thisExprUse(BlockRange(), &thisArgNode->gtOp.gtOp1, thisArgNode);
         thisExprUse.ReplaceWithLclVar(comp, m_block->getBBWeight(comp), delegateInvokeTmp);
 
         originalThisExpr = thisExprUse.Def(); // it's changed; reload it.
@@ -2094,11 +2087,11 @@ GenTree* Lowering::LowerDelegateInvoke(GenTreeCall* call)
                                                              nullptr,
                                                              0,
                                                              comp->eeGetEEInfo()->offsetOfDelegateInstance);
-    m_blockRange.InsertAfter(newThisAddr, originalThisExpr);
+    BlockRange().InsertAfter(newThisAddr, originalThisExpr);
 
     GenTree* newThis = comp->gtNewOperNode(GT_IND, TYP_REF, newThisAddr);
     newThis->SetCosts(IND_COST_EX, 2);
-    m_blockRange.InsertAfter(newThis, newThisAddr);
+    BlockRange().InsertAfter(newThis, newThisAddr);
     thisArgNode->gtOp.gtOp1 = newThis;
 
     // the control target is
@@ -2298,7 +2291,7 @@ void Lowering::InsertPInvokeMethodProlog()
 
     JITDUMP("======= Inserting PInvoke method prolog\n");
 
-    LIR::Range firstBlockRange = LIR::AsRange(comp->fgFirstBB);
+    LIR::Range& firstBlockRange = LIR::AsRange(comp->fgFirstBB);
 
     const CORINFO_EE_INFO* pInfo = comp->eeGetEEInfo();
     const CORINFO_EE_INFO::InlinedCallFrameInfo& callFrameInfo = pInfo->inlinedCallFrameInfo;
@@ -2334,7 +2327,7 @@ void Lowering::InsertPInvokeMethodProlog()
     GenTree* insertionPoint = firstBlockRange.FirstNonPhiOrCatchArgNode();
     if (insertionPoint == nullptr)
     {
-        insertionPoint = firstBlockRange.EndExclusive();
+        insertionPoint = firstBlockRange.LastNode();
     }
 
     comp->fgMorphTree(store);
@@ -2411,9 +2404,9 @@ void Lowering::InsertPInvokeMethodEpilog(BasicBlock *returnBB
     // Method doing PInvoke calls has exactly one return block unless it has "jmp" or tail calls.
     assert(((returnBB == comp->genReturnBB) && (returnBB->bbJumpKind == BBJ_RETURN)) || returnBB->endsWithTailCallOrJmp(comp));
 
-    LIR::Range returnBlockRange = LIR::AsRange(returnBB);
+    LIR::Range& returnBlockRange = LIR::AsRange(returnBB);
 
-    GenTree* insertionPoint = returnBlockRange.EndExclusive();
+    GenTree* insertionPoint = returnBlockRange.LastNode();
 
     // Note: PInvoke Method Epilog (PME) needs to be inserted just before GT_RETURN, GT_JMP or GT_CALL node in execution
     // order so that it is guaranteed that there will be no further PInvokes after that point in the method.
@@ -2469,7 +2462,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
     if (call->gtCallType == CT_INDIRECT)
     {
         bool isClosed;
-        insertBefore = m_blockRange.GetTreeRange(call->gtCallAddr, &isClosed).Begin();
+        insertBefore = BlockRange().GetTreeRange(call->gtCallAddr, &isClosed).FirstNode();
         assert(isClosed);
     }
 
@@ -2490,7 +2483,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
         GenTree* helperCall = comp->gtNewHelperCallNode(CORINFO_HELP_JIT_PINVOKE_BEGIN, TYP_VOID, 0, comp->gtNewArgList(frameAddr));
 
         comp->fgMorphTree(helperCall);
-        m_blockRange.InsertBefore(LIR::SeqTree(comp, helperCall), insertBefore);
+        BlockRange().InsertBefore(LIR::SeqTree(comp, helperCall), insertBefore);
         return;
     }
 #endif
@@ -2550,7 +2543,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
                           callFrameInfo.offsetOfCallTarget);
         store->gtOp1 = src;
 
-        m_blockRange.InsertBefore(LIR::SeqTree(comp, store), insertBefore);
+        BlockRange().InsertBefore(LIR::SeqTree(comp, store), insertBefore);
     }
 
 #ifdef _TARGET_X86_
@@ -2566,7 +2559,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
 
     storeCallSiteSP->gtOp1 = PhysReg(REG_SPBASE);
 
-    m_blockRange.InsertBefore(LIR::SeqTree(comp, storeCallSiteSP), insertBefore);
+    BlockRange().InsertBefore(LIR::SeqTree(comp, storeCallSiteSP), insertBefore);
 
 #endif
 
@@ -2585,7 +2578,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
     labelRef->gtType = TYP_I_IMPL;
     storeLab->gtOp1 = labelRef;
 
-    m_blockRange.InsertBefore(LIR::SeqTree(comp, storeLab), insertBefore);
+    BlockRange().InsertBefore(LIR::SeqTree(comp, storeLab), insertBefore);
 
     if (!(comp->opts.eeFlags & CORJIT_FLG_IL_STUB))
     {
@@ -2595,7 +2588,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
         //
         // Stubs do this once per stub, not once per call.
         GenTree* frameUpd = CreateFrameLinkUpdate(PushFrame);
-        m_blockRange.InsertBefore(LIR::SeqTree(comp, frameUpd), insertBefore);
+        BlockRange().InsertBefore(LIR::SeqTree(comp, frameUpd), insertBefore);
     }
 
     // IMPORTANT **** This instruction must come last!!! ****
@@ -2604,7 +2597,7 @@ void Lowering::InsertPInvokeCallProlog(GenTreeCall* call)
     //  [tcb + offsetOfGcState] = 0
 
     GenTree* storeGCState = SetGCState(0);
-    m_blockRange.InsertBefore(LIR::SeqTree(comp, storeGCState), insertBefore);
+    BlockRange().InsertBefore(LIR::SeqTree(comp, storeGCState), insertBefore);
 }
 
 
@@ -2635,7 +2628,7 @@ void Lowering::InsertPInvokeCallEpilog(GenTreeCall* call)
         GenTree* helperCall = comp->gtNewHelperCallNode(CORINFO_HELP_JIT_PINVOKE_END, TYP_VOID, 0, comp->gtNewArgList(frameAddr));
 
         comp->fgMorphTree(helperCall);
-        m_blockRange.InsertAfter(LIR::SeqTree(comp, helperCall), call);
+        BlockRange().InsertAfter(LIR::SeqTree(comp, helperCall), call);
         return;
     }
 #endif
@@ -2644,18 +2637,18 @@ void Lowering::InsertPInvokeCallEpilog(GenTreeCall* call)
     GenTree* insertionPoint = call;
 
     GenTree* tree = SetGCState(1);
-    m_blockRange.InsertAfter(LIR::SeqTree(comp, tree), insertionPoint);
+    BlockRange().InsertAfter(LIR::SeqTree(comp, tree), insertionPoint);
     insertionPoint = tree;
 
     tree = CreateReturnTrapSeq();
-    m_blockRange.InsertAfter(LIR::SeqTree(comp, tree), insertionPoint);
+    BlockRange().InsertAfter(LIR::SeqTree(comp, tree), insertionPoint);
     insertionPoint = tree;
 
     // Pop the frame if necessasry
     if (!(comp->opts.eeFlags & CORJIT_FLG_IL_STUB))
     {
         tree = CreateFrameLinkUpdate(PopFrame);
-        m_blockRange.InsertAfter(LIR::SeqTree(comp, tree), insertionPoint);
+        BlockRange().InsertAfter(LIR::SeqTree(comp, tree), insertionPoint);
     }
 }
 
@@ -2731,7 +2724,7 @@ GenTree* Lowering::LowerNonvirtPinvokeCall(GenTreeCall* call)
     // The PINVOKE_PROLOG op signals this to the code generator/emitter.
 
     GenTree* prolog = new (comp, GT_NOP) GenTree(GT_PINVOKE_PROLOG, TYP_VOID);
-    m_blockRange.InsertBefore(prolog, call);
+    BlockRange().InsertBefore(prolog, call);
 
     InsertPInvokeCallProlog(call);
 
@@ -2833,7 +2826,7 @@ GenTree* Lowering::LowerVirtualVtableCall(GenTreeCall* call)
             vtableCallTemp = comp->lvaGrabTemp(true DEBUGARG("virtual vtable call"));
         }
 
-        LIR::Use thisPtrUse(m_blockRange, &(argEntry->node->gtOp.gtOp1), argEntry->node);
+        LIR::Use thisPtrUse(BlockRange(), &(argEntry->node->gtOp.gtOp1), argEntry->node);
         thisPtrUse.ReplaceWithLclVar(comp, m_block->getBBWeight(comp), vtableCallTemp);
 
         lclNum = vtableCallTemp;
@@ -2931,7 +2924,7 @@ GenTree* Lowering::LowerVirtualStubCall(GenTreeCall* call)
         // All we have to do here is add an indirection to generate the actual call target.
 
         GenTree* ind = Ind(call->gtCallAddr);
-        m_blockRange.InsertAfter(ind, call->gtCallAddr);
+        BlockRange().InsertAfter(ind, call->gtCallAddr);
         call->gtCallAddr = ind;
     }
     else
@@ -3007,7 +3000,7 @@ void Lowering::AddrModeCleanupHelper(GenTreeAddrMode* addrMode, GenTree* node)
         AddrModeCleanupHelper(addrMode, operand);
     }
 
-    m_blockRange.Remove(node);
+    BlockRange().Remove(node);
 }
 
 // given two nodes which will be used in an addressing mode (base, index)
@@ -3152,7 +3145,7 @@ GenTree* Lowering::TryCreateAddrMode(LIR::Use&& use, bool isIndir)
         addrMode->gtFlags &= ~(GTF_REVERSE_OPS);
     }
 
-    m_blockRange.InsertAfter(addrMode, addr);
+    BlockRange().InsertAfter(addrMode, addr);
 
     // Now we need to remove all the nodes subsumed by the addrMode
     AddrModeCleanupHelper(addrMode, addr);
@@ -3185,7 +3178,7 @@ GenTree* Lowering::LowerAdd(GenTree* node)
         return next;
 
     LIR::Use use;
-    if (!m_blockRange.TryGetUse(node, &use))
+    if (!BlockRange().TryGetUse(node, &use))
         return next;
 
     // if this is a child of an indir, let the parent handle it
@@ -3307,7 +3300,7 @@ GenTree* Lowering::LowerSignedDivOrMod(GenTreePtr node)
 
     // We're committed to the conversion now. Go find the use.
     LIR::Use use;
-    if (!m_blockRange.TryGetUse(node, &use))
+    if (!BlockRange().TryGetUse(node, &use))
     {
         assert(!"signed DIV/MOD node is unused");
         return next;
@@ -3318,7 +3311,7 @@ GenTree* Lowering::LowerSignedDivOrMod(GenTreePtr node)
 
     unsigned curBBWeight = comp->compCurBB->getBBWeight(comp);
 
-    LIR::Use opDividend(m_blockRange, &divMod->gtOp.gtOp1, divMod);
+    LIR::Use opDividend(BlockRange(), &divMod->gtOp.gtOp1, divMod);
     opDividend.ReplaceWithLclVar(comp, curBBWeight);
 
     dividend = divMod->gtGetOp1();
@@ -3384,13 +3377,12 @@ GenTree* Lowering::LowerSignedDivOrMod(GenTreePtr node)
 
     // Remove the divisor and dividend nodes from the linear order, 
     // since we have reused them and will resequence the tree
-    m_blockRange.Remove(divisor);
-    m_blockRange.Remove(dividend);
+    BlockRange().Remove(divisor);
+    BlockRange().Remove(dividend);
 
     // linearize and insert the new tree before the original divMod node
-    LIR::Range range = LIR::SeqTree(comp, newDivMod);
-    m_blockRange.InsertBefore(range, divMod);
-    m_blockRange.Remove(divMod);
+    BlockRange().InsertBefore(LIR::SeqTree(comp, newDivMod), divMod);
+    BlockRange().Remove(divMod);
 
     // replace the original divmod node with the new divmod tree
     use.ReplaceWith(comp, newDivMod);
@@ -3410,7 +3402,7 @@ void Lowering::LowerStoreInd(GenTree* node)
     assert(node != nullptr);
     assert(node->OperGet() == GT_STOREIND);
 
-    TryCreateAddrMode(LIR::Use(m_blockRange, &node->gtOp.gtOp1, node), true);
+    TryCreateAddrMode(LIR::Use(BlockRange(), &node->gtOp.gtOp1, node), true);
 
     // Mark all GT_STOREIND nodes to indicate that it is not known
     // whether it represents a RMW memory op.
@@ -3480,7 +3472,7 @@ GenTree* Lowering::LowerArrElem(GenTree* node)
     // We need to have the array object in a lclVar.
     if (!arrElem->gtArrObj->IsLocal())
     {
-        LIR::Use arrObjUse(m_blockRange, &arrElem->gtArrObj, arrElem);
+        LIR::Use arrObjUse(BlockRange(), &arrElem->gtArrObj, arrElem);
         arrObjUse.ReplaceWithLclVar(comp, blockWeight);
     }
 
@@ -3491,7 +3483,7 @@ GenTree* Lowering::LowerArrElem(GenTree* node)
 
     // The first ArrOffs node will have 0 for the offset of the previous dimension.
     GenTree* prevArrOffs = new(comp, GT_CNS_INT) GenTreeIntCon(TYP_I_IMPL, 0);
-    m_blockRange.InsertBefore(prevArrOffs, insertionPoint);
+    BlockRange().InsertBefore(prevArrOffs, insertionPoint);
 
     for (unsigned char dim = 0; dim < rank; dim++)
     {
@@ -3506,22 +3498,22 @@ GenTree* Lowering::LowerArrElem(GenTree* node)
         else
         {
             idxArrObjNode = comp->gtClone(arrObjNode);
-            m_blockRange.InsertBefore(idxArrObjNode, insertionPoint);
+            BlockRange().InsertBefore(idxArrObjNode, insertionPoint);
         }
 
         // Next comes the GT_ARR_INDEX node.
         GenTreeArrIndex* arrMDIdx = new(comp, GT_ARR_INDEX)
             GenTreeArrIndex(TYP_INT, idxArrObjNode, indexNode, dim, rank, arrElem->gtArrElem.gtArrElemType);
         arrMDIdx->gtFlags |= ((idxArrObjNode->gtFlags|indexNode->gtFlags) & GTF_ALL_EFFECT);
-        m_blockRange.InsertBefore(arrMDIdx, insertionPoint);
+        BlockRange().InsertBefore(arrMDIdx, insertionPoint);
 
         GenTree* offsArrObjNode = comp->gtClone(arrObjNode);
-        m_blockRange.InsertBefore(offsArrObjNode, insertionPoint);
+        BlockRange().InsertBefore(offsArrObjNode, insertionPoint);
 
         GenTreeArrOffs* arrOffs = new(comp, GT_ARR_OFFSET)
             GenTreeArrOffs(TYP_I_IMPL, prevArrOffs, arrMDIdx, offsArrObjNode, dim, rank, arrElem->gtArrElem.gtArrElemType);
         arrOffs->gtFlags |= ((prevArrOffs->gtFlags|arrMDIdx->gtFlags|offsArrObjNode->gtFlags) & GTF_ALL_EFFECT);
-        m_blockRange.InsertBefore(arrOffs, insertionPoint);
+        BlockRange().InsertBefore(arrOffs, insertionPoint);
 
         prevArrOffs = arrOffs;
     }
@@ -3536,14 +3528,14 @@ GenTree* Lowering::LowerArrElem(GenTree* node)
         // We do the address arithmetic in TYP_I_IMPL, though note that the lower bounds and lengths in memory are TYP_INT
         GenTreePtr scaleNode = new(comp, GT_CNS_INT) GenTreeIntCon(TYP_I_IMPL, scale);
         GenTreePtr mulNode = new(comp, GT_MUL) GenTreeOp(GT_MUL, TYP_I_IMPL, leaIndexNode, scaleNode); 
-        m_blockRange.InsertBefore(scaleNode, insertionPoint);
-        m_blockRange.InsertBefore(mulNode, insertionPoint);
+        BlockRange().InsertBefore(scaleNode, insertionPoint);
+        BlockRange().InsertBefore(mulNode, insertionPoint);
         leaIndexNode = mulNode;
         scale = 1;
     }
 
     GenTreePtr leaBase = comp->gtClone(arrObjNode);
-    m_blockRange.InsertBefore(leaBase, insertionPoint);
+    BlockRange().InsertBefore(leaBase, insertionPoint);
 
     GenTreePtr leaNode = new(comp, GT_LEA) GenTreeAddrMode(arrElem->TypeGet(), leaBase, leaIndexNode, scale, offset);
     leaNode->gtFlags |= GTF_REVERSE_OPS;
@@ -3552,15 +3544,15 @@ GenTree* Lowering::LowerArrElem(GenTree* node)
     // dataflow tree rooted at `leaNode`.
     comp->gtPrepareCost(leaNode);
 
-    m_blockRange.InsertBefore(leaNode, insertionPoint);
+    BlockRange().InsertBefore(leaNode, insertionPoint);
 
     LIR::Use arrElemUse;
-    if (m_blockRange.TryGetUse(arrElem, &arrElemUse))
+    if (BlockRange().TryGetUse(arrElem, &arrElemUse))
     {
         arrElemUse.ReplaceWith(comp, leaNode);
     }
 
-    m_blockRange.Remove(arrElem);
+    BlockRange().Remove(arrElem);
 
     JITDUMP("Results of lowering ArrElem:\n");
     DISPTREE(leaNode);
@@ -3696,9 +3688,7 @@ void Lowering::DoPhase()
         currentLoc += 2;
 
         m_block = block;
-        m_blockRange = LIR::AsRange(block);
-
-        for (GenTree* node = m_blockRange.FirstNonPhiNode(), *end = m_blockRange.End(); node != end; node = node->gtNext)
+        for (GenTree* node : BlockRange().NonPhiNodes())
         {
             /* We increment the number position of each tree node by 2 to
             * simplify the logic when there's the case of a tree that implicitly
@@ -3729,7 +3719,7 @@ void Lowering::DoPhase()
             currentLoc += 2;
         }
 
-        for (GenTree* node = m_blockRange.FirstNonPhiNode(), *end = m_blockRange.End(); node != end; node = node->gtNext)
+        for (GenTree* node : BlockRange().NonPhiNodes())
         {
             TreeNodeInfoInit(node);
 
@@ -3755,7 +3745,7 @@ void Lowering::DoPhase()
 #endif
         }
 
-        assert(m_blockRange.CheckLIR(comp, true));
+        assert(BlockRange().CheckLIR(comp, true));
     }
     DBEXEC(VERBOSE, DumpNodeInfoMap());
 }
@@ -3867,7 +3857,7 @@ bool Lowering::CheckBlock(Compiler* compiler, BasicBlock* block)
 {
     assert(block->isEmpty() || block->IsLIR());
 
-    LIR::Range blockRange = LIR::AsRange(block);
+    LIR::Range& blockRange = LIR::AsRange(block);
     for (GenTree* node : blockRange)
     {
         CheckNode(node);
@@ -3884,7 +3874,6 @@ void Lowering::LowerBlock(BasicBlock* block)
     assert(block->isEmpty() || block->IsLIR());
 
     m_block = block;
-    m_blockRange = LIR::AsRange(block);
 
     // TODO(pdg): some of the lowering methods insert calls before the node
     // being lowered. It is not clear that the inserted calls are themselves
@@ -3894,9 +3883,8 @@ void Lowering::LowerBlock(BasicBlock* block)
     //
     // See e.g. uses of InsertPInvoke{Method,Call}{Prolog,Epilog}.
 
-    GenTree* node = m_blockRange.FirstNonPhiNode();
-    GenTree* end = m_blockRange.End();
-    while (node != end)
+    GenTree* node = BlockRange().FirstNonPhiNode();
+    while (node != nullptr)
     {
         node = LowerNode(node);
     }
@@ -4136,8 +4124,7 @@ void Lowering::DumpNodeInfoMap()
 
     for (BasicBlock* block = comp->fgFirstBB; block != nullptr; block = block->bbNext)
     {
-        LIR::Range blockRange = LIR::AsRange(block);
-        for (GenTree* node = blockRange.FirstNonPhiNode(), *end = blockRange.End(); node != end; node = node->gtNext)
+        for (GenTree* node : LIR::AsRange(block).NonPhiNodes())
         {
             comp->gtDispTree(node, nullptr, nullptr, true);
             printf("    +");

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -257,10 +257,14 @@ private:
     // Checks for memory conflicts in the instructions between childNode and parentNode, and returns true if childNode can be contained.
     bool IsSafeToContainMem(GenTree* parentNode, GenTree* childNode);
 
+    inline LIR::Range& BlockRange() const
+    {
+        return LIR::AsRange(m_block);
+    }
+
     LinearScan* m_lsra;
     unsigned vtableCallTemp; // local variable we use as a temp for vtable calls
     BasicBlock* m_block;
-    LIR::Range m_blockRange;    // The range of nodes in the current block.
 };
 
 #endif // _LOWER_H_

--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -1868,7 +1868,7 @@ void Lowering::LowerCast(GenTree* tree)
 
         tree->gtFlags &= ~GTF_UNSIGNED;
         tree->gtOp.gtOp1 = tmp;
-        m_blockRange.InsertAfter(tmp, op1);
+        BlockRange().InsertAfter(tmp, op1);
     }
 }
 

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -3168,7 +3168,7 @@ void Lowering::LowerCmp(GenTreePtr tree)
                             }
                         }
 
-                        m_blockRange.Remove(removeTreeNode);
+                        BlockRange().Remove(removeTreeNode);
 #ifdef DEBUG
                         if (comp->verbose)
                         {
@@ -3312,7 +3312,7 @@ void Lowering::LowerCast(GenTree* tree)
 
         tree->gtFlags &= ~GTF_UNSIGNED;
         tree->gtOp.gtOp1 = tmp;
-        m_blockRange.InsertAfter(tmp, op1);
+        BlockRange().InsertAfter(tmp, op1);
     }
 }
 
@@ -3343,7 +3343,7 @@ bool Lowering::IsBinOpInRMWStoreInd(GenTreePtr tree)
     }
 
     LIR::Use use;
-    if (!m_blockRange.TryGetUse(tree, &use) || use.User()->OperGet() != GT_STOREIND || use.User()->gtGetOp2() != tree)
+    if (!BlockRange().TryGetUse(tree, &use) || use.User()->OperGet() != GT_STOREIND || use.User()->gtGetOp2() != tree)
     {
         return false;
     }

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -7719,7 +7719,7 @@ LinearScan::insertUpperVectorSaveAndReload(GenTreePtr tree, RefPosition* refPosi
     regNumber spillReg = refPosition->assignedReg();
     bool spillToMem = refPosition->spillAfter;
 
-    LIR::Range blockRange = LIR::AsRange(block);
+    LIR::Range& blockRange = LIR::AsRange(block);
 
     // First, insert the save as an embedded statement before the call.
 

--- a/src/jit/nodeinfo.h
+++ b/src/jit/nodeinfo.h
@@ -6,6 +6,8 @@
 #ifndef _NODEINFO_H_
 #define _NODEINFO_H_
 
+struct GenTree;
+
 class LinearScan;
 typedef unsigned int LsraLocation;
 

--- a/src/jit/rationalize.h
+++ b/src/jit/rationalize.h
@@ -9,7 +9,6 @@ class Rationalizer : public Phase
 {
 private:
     BasicBlock* m_block;
-    LIR::Range m_range;
     GenTreeStmt* m_statement;
 
 public:
@@ -31,6 +30,11 @@ public:
     static void RewriteAssignmentIntoStoreLcl(GenTreeOp* assignment);
 
 private:
+    inline LIR::Range& BlockRange() const
+    {
+        return LIR::AsRange(m_block);
+    }
+
     // SIMD related transformations
     void RewriteInitBlk(LIR::Use& use);
     void RewriteCopyBlk(LIR::Use& use);


### PR DESCRIPTION
The most interesting change here is that LIR::Range is no longer final and has been
split into two types: ReadOnlyRange and Range. The latter is used for subranges; the
former is used for ranges that are not subranges (i.e. blocks and scratch ranges).

LIR::Range has also been made the base type of BasicBlock, thus obviating the need
for the hokey pointer tricks it used to play for polymorphism. Because LIR::Range
is no longer a final class, it is now possible to slice range values. As a result,
viewing a BasicBlock as an LIR::Range now returns a reference to the range rather
than the range itself.

Although some pains have been taken to help guard against the existence of invalid
subranges, it remains possible to create them. For example, consider the following:

```
    // View the block as a range
    LIR::Range& blockRange = LIR::AsRange(block);

    // Create a range from the first non-phi node in the block to the last node in
    // the block
    LIR::ReadOnlyRange nonPhis = blockRange.NonPhiNodes();

    // Remove the last node from the block
    blockRange.Remove(blockRange.LastNode());
```

After the removal of the last node in the block, the last node of `nonPhis` is no
longer linked to any of the other nodes in `nonPhis`.

Other, smaller changes include:
- LIR::Range::{Begin,End,EndExclusive} are dead. Long live {FirstNode(),EndNode()}.
- Some code snippets that were calculating the last node of a block inline now use
  BasicBlock::lastNode
- BasicBlock::IsLIR() may now return true for an empty block. Blocks are marked as
  LIR using a bit stolen from `bbNum`. HIR blocks are transitioned to LIR blocks
  as part of rationalize, and all blocks that are created after rationalize are
  automatically marked as LIR blocks.
