### PR TITLE
Remove extra calls to CheckLIR().

### DIFF
--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -292,8 +292,6 @@ GenTree* DecomposeLongs::FinalizeDecomposition(LIR::Use& use, GenTree* loResult,
 
     use.ReplaceWith(m_compiler, gtLong);
 
-    assert(BlockRange().CheckLIR(m_compiler));
-
     return gtLong->gtNext;
 }
 
@@ -451,7 +449,6 @@ GenTree* DecomposeLongs::DecomposeStoreLclVar(LIR::Use& use)
     hiStore->CopyCosts(tree);
     BlockRange().InsertAfter(tree, hiStore);
 
-    assert(BlockRange().CheckLIR(m_compiler));
     return hiStore->gtNext;
 }
 
@@ -728,8 +725,6 @@ GenTree* DecomposeLongs::DecomposeStoreInd(LIR::Use& use)
     m_compiler->gtPrepareCost(storeIndHigh);
 
     BlockRange().InsertAfter(storeIndLow, dataHigh, addrBaseHigh, addrHigh, storeIndHigh);
-
-    assert(BlockRange().CheckLIR(m_compiler));
 
     return storeIndHigh;
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -15954,7 +15954,7 @@ REPEAT:;
     {
         for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
         {
-            assert(LIR::AsRange(block).CheckLIR(this));
+            LIR::AsRange(block).CheckLIR(this);
         }
     }
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -8701,9 +8701,6 @@ BasicBlock* Compiler::fgSplitBlockAfterNode(BasicBlock* curr, GenTree* node)
         assert(curr->bbTreeList == nullptr); // if no node was given then it better be an empty block
     }
 
-    assert(LIR::AsRange(curr).CheckLIR(this));
-    assert(LIR::AsRange(newBlock).CheckLIR(this));
-
     return newBlock;
 }
 
@@ -9468,8 +9465,6 @@ void                Compiler::fgCompactBlocks(BasicBlock* block, BasicBlock* bNe
             LIR::Range nextNodes = nextRange.Remove(nextFirstNonPhi, nextRange.LastNode());
             blockRange.InsertAfter(blockRange.LastNode(), std::move(nextNodes));
         }
-
-        assert(blockRange.CheckLIR(this));
     }
     else
     {
@@ -15954,6 +15949,15 @@ REPEAT:;
         fgDispBasicBlocks(verboseTrees);
         fgDispHandlerTab();
     }
+
+    if (compRationalIRForm)
+    {
+        for (BasicBlock* block = fgFirstBB; block != nullptr; block = block->bbNext)
+        {
+            assert(LIR::AsRange(block).CheckLIR(this));
+        }
+    }
+
     fgVerifyHandlerTab();
     // Make sure that the predecessor lists are accurate
     fgDebugCheckBBlist();

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1207,8 +1207,6 @@ void Lowering::LowerCall(GenTree* node)
             break;
         }
     }
-
-    assert(BlockRange().CheckLIR(comp));
     
     if (call->IsTailCallViaHelper())
     {
@@ -1268,8 +1266,6 @@ void Lowering::LowerCall(GenTree* node)
         call->gtControlExpr = result;
     }
 #endif //!_TARGET_ARM_
-
-    assert(BlockRange().CheckLIR(comp));
 
     if (comp->opts.IsJit64Compat())
     {


### PR DESCRIPTION
This function can be pretty expensive, and really only ought to be
called once all modifications made to a particular block by a
particular phase are complete.
