### PR TITLE
Update LIR dumps.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2115,13 +2115,9 @@ public:
                                              IndentStack*           indentStack);
     void                    gtDispFieldSeq  (FieldSeqNode*          pfsn);
 
-    GenTreePtr              gtDispLinearTree(GenTreeStmt*           curStmt,
-                                             GenTreePtr             nextLinearNode,
-                                             GenTreePtr             tree,
-                                             IndentStack*           indentStack,
-                                             __in_opt const char*   msg = nullptr);
-    GenTreePtr              gtDispLinearStmt(GenTreeStmt*           stmt,
-                                             IndentStack*           indentStack = nullptr);
+    void                    gtDispRange     (LIR::ReadOnlyRange const & range);
+
+    void                    gtDispTreeRange (LIR::Range& containingRange, GenTree* tree);
 
     void                    gtDispLIRNode   (GenTree*               node);
 #endif

--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -629,14 +629,14 @@ GenTree* DecomposeLongs::DecomposeStoreInd(LIR::Use& use)
     LIR::Use address(BlockRange(), &tree->gtOp.gtOp1, tree);
     address.ReplaceWithLclVar(m_compiler, blockWeight);
     JITDUMP("[DecomposeStoreInd]: Saving address tree to a temp var:\n");
-    DISPTREE(address.Def());
+    DISPTREERANGE(BlockRange(), address.Def());
 
     if (!gtLong->gtOp.gtOp1->OperIsLeaf())
     {
         LIR::Use op1(BlockRange(), &gtLong->gtOp.gtOp1, gtLong);
         op1.ReplaceWithLclVar(m_compiler, blockWeight);
         JITDUMP("[DecomposeStoreInd]: Saving low data tree to a temp var:\n");
-        DISPTREE(op1.Def());
+        DISPTREERANGE(BlockRange(), op1.Def());
     }
 
     if (!gtLong->gtOp.gtOp2->OperIsLeaf())
@@ -644,7 +644,7 @@ GenTree* DecomposeLongs::DecomposeStoreInd(LIR::Use& use)
         LIR::Use op2(BlockRange(), &gtLong->gtOp.gtOp2, gtLong);
         op2.ReplaceWithLclVar(m_compiler, blockWeight);
         JITDUMP("[DecomposeStoreInd]: Saving high data tree to a temp var:\n");
-        DISPTREE(op2.Def());
+        DISPTREERANGE(BlockRange(), op2.Def());
     }
 
     // Example trees after embedded statements for address and data are added.
@@ -788,7 +788,7 @@ GenTree* DecomposeLongs::DecomposeInd(LIR::Use& use)
     LIR::Use address(BlockRange(), &indLow->gtOp.gtOp1, indLow);
     address.ReplaceWithLclVar(m_compiler, m_block->getBBWeight(m_compiler));
     JITDUMP("[DecomposeInd]: Saving addr tree to a temp var:\n");
-    DISPTREE(address.Def());
+    DISPTREERANGE(BlockRange(), address.Def());
 
     // Change the type of lower ind.
     indLow->gtType = TYP_INT;

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -19532,10 +19532,7 @@ void                Compiler::fgDumpBlock(BasicBlock* block)
     }
     else
     {
-        for (GenTree* node = block->bbTreeList; node != nullptr; node = node->gtNext)
-        {
-            gtDispLIRNode(node);
-        }
+        gtDispRange(LIR::AsRange(block));
     }
 }
 

--- a/src/jit/jit.h
+++ b/src/jit/jit.h
@@ -501,7 +501,9 @@ void JitDump(const char* pcFormat, ...);
 #define JITLOG_THIS(t, x) { (t)->JitLogEE x; }
 #define DBEXEC(flg, expr) if (flg) {expr;}
 #define DISPNODE(t) if (JitTls::GetCompiler()->verbose) JitTls::GetCompiler()->gtDispTree(t, nullptr, nullptr, true);
-#define DISPTREE(x) if (JitTls::GetCompiler()->verbose) JitTls::GetCompiler()->gtDispTree(x)
+#define DISPTREE(t) if (JitTls::GetCompiler()->verbose) JitTls::GetCompiler()->gtDispTree(t);
+#define DISPRANGE(range) if (JitTls::GetCompiler()->verbose) JitTls::GetCompiler()->gtDispRange(range);
+#define DISPTREERANGE(range, t) if (JitTls::GetCompiler()->verbose) JitTls::GetCompiler()->gtDispTreeRange(range, t);
 #define VERBOSE JitTls::GetCompiler()->verbose
 #else // !DEBUG
 #define JITDUMP(...)

--- a/src/jit/jit.h
+++ b/src/jit/jit.h
@@ -511,7 +511,9 @@ void JitDump(const char* pcFormat, ...);
 #define JITLOG_THIS(t, x)
 #define DBEXEC(flg, expr)
 #define DISPNODE(t)
-#define DISPTREE(x)
+#define DISPTREE(t)
+#define DISPRANGE(range)
+#define DISPTREERANGE(range, t)
 #define VERBOSE 0
 #endif // !DEBUG
 

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -286,7 +286,7 @@ unsigned LIR::Use::ReplaceWithLclVar(Compiler* compiler, unsigned blockWeight, u
     ReplaceWith(compiler, load);
 
     JITDUMP("ReplaceWithLclVar created store :\n");
-    DISPTREE(store);
+    DISPNODE(store);
 
     return lclNum;
 }

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -2693,10 +2693,6 @@ bool Compiler::fgRemoveDeadStore(GenTree** pTree, LclVarDsc* varDsc, VARSET_TP l
 
             noway_assert(!VarSetOps::IsMember(this, life, varDsc->lvVarIndex));
 
-            JITDUMP("interior assign\n");
-            DISPTREE(asgNode);
-            JITDUMP("\n");
-
             if (rhsNode->gtFlags & GTF_SIDE_EFFECT)
             {
                 /* :-( we have side effects */

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1153,7 +1153,7 @@ void Lowering::LowerCall(GenTree* node)
     GenTreeCall* call = node->AsCall();
 
     JITDUMP("lowering call (before):\n");
-    DISPTREE(call);
+    DISPTREERANGE(BlockRange(), call);
     JITDUMP("\n");
     
     LowerArgsForCall(call);
@@ -1230,7 +1230,7 @@ void Lowering::LowerCall(GenTree* node)
         LIR::Range resultRange = LIR::SeqTree(comp, result);
 
         JITDUMP("results of lowering call:\n");
-        DISPTREE(result);
+        DISPRANGE(resultRange);
 
         GenTree* insertionPoint = call;
         if (!call->IsTailCallViaHelper())
@@ -1273,7 +1273,7 @@ void Lowering::LowerCall(GenTree* node)
     }
 
     JITDUMP("lowering call (after):\n");
-    DISPTREE(call);
+    DISPTREERANGE(BlockRange(), call);
     JITDUMP("\n");
 }
 
@@ -1870,7 +1870,7 @@ void Lowering::LowerJmpMethod(GenTree* jmp)
     assert(jmp->OperGet() == GT_JMP);
 
     JITDUMP("lowering GT_JMP\n");
-    DISPTREE(jmp);
+    DISPNODE(jmp);
     JITDUMP("============");
 
     // If PInvokes are in-lined, we have to remember to execute PInvoke method epilog anywhere that
@@ -1887,7 +1887,7 @@ void Lowering::LowerRet(GenTree* ret)
     assert(ret->OperGet() == GT_RETURN);
 
     JITDUMP("lowering GT_RETURN\n");
-    DISPTREE(ret);
+    DISPNODE(ret);
     JITDUMP("============");
 
     // Method doing PInvokes has exactly one return block unless it has tail calls.
@@ -2329,7 +2329,7 @@ void Lowering::InsertPInvokeMethodProlog()
     comp->fgMorphTree(store);
     firstBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, store));
 
-    DISPTREE(store);
+    DISPTREERANGE(firstBlockRange, store);
 
 #ifndef _TARGET_X86_ // For x86, this step is done at the call site (due to stack pointer not being static in the function).
 
@@ -2343,7 +2343,7 @@ void Lowering::InsertPInvokeMethodProlog()
 
     firstBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, storeSP));
 
-    DISPTREE(storeSP);
+    DISPTREERANGE(firstBlockRange, storeSP);
 
 #endif // !_TARGET_X86_
 
@@ -2357,7 +2357,7 @@ void Lowering::InsertPInvokeMethodProlog()
 
     firstBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, storeFP));
 
-    DISPTREE(storeFP);
+    DISPTREERANGE(firstBlockRange, storeFP);
 
     // --------------------------------------------------------
 
@@ -2367,7 +2367,7 @@ void Lowering::InsertPInvokeMethodProlog()
         // The init routine sets InlinedCallFrame's m_pNext, so we just set the thead's top-of-stack
         GenTree* frameUpd = CreateFrameLinkUpdate(PushFrame);
         firstBlockRange.InsertBefore(insertionPoint, LIR::SeqTree(comp, frameUpd));
-        DISPTREE(frameUpd);
+        DISPTREERANGE(firstBlockRange, frameUpd);
     }
 }
 
@@ -3460,7 +3460,7 @@ GenTree* Lowering::LowerArrElem(GenTree* node)
 
     JITDUMP("Lowering ArrElem\n");
     JITDUMP("============\n");
-    DISPTREE(arrElem);
+    DISPTREERANGE(BlockRange(), arrElem);
     JITDUMP("\n");
 
     assert(arrElem->gtArrObj->TypeGet() == TYP_REF);
@@ -3550,7 +3550,7 @@ GenTree* Lowering::LowerArrElem(GenTree* node)
     BlockRange().Remove(arrElem);
 
     JITDUMP("Results of lowering ArrElem:\n");
-    DISPTREE(leaNode);
+    DISPTREERANGE(BlockRange(), leaNode);
     JITDUMP("\n\n");
 
     return leaNode;

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -3591,7 +3591,7 @@ bool Lowering::SetStoreIndOpCountsIfRMWMemOp(GenTreePtr storeInd)
     if (!IsRMWMemOpRootedAtStoreInd(storeInd, &indirCandidate, &indirOpSource))
     {
         JITDUMP("Lower of StoreInd didn't mark the node as self contained for reason: %d\n", storeInd->AsStoreInd()->GetRMWStatus());
-        DISPTREE(storeInd);
+        DISPTREERANGE(BlockRange(), storeInd);
         return false;
     }
 
@@ -3632,7 +3632,7 @@ bool Lowering::SetStoreIndOpCountsIfRMWMemOp(GenTreePtr storeInd)
         JITDUMP("Lower succesfully detected an assignment of the form: *addrMode = UnaryOp(*addrMode)\n");
         info->srcCount = 0;
     }
-    DISPTREE(storeInd);
+    DISPTREERANGE(BlockRange(), storeInd);
     
     m_lsra->clearOperandCounts(indirSrc);
     m_lsra->clearOperandCounts(indirCandidate);

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -3913,7 +3913,6 @@ LinearScan::insertZeroInitRefPositions()
 
             GenTree * firstStmt = getNonEmptyBlock(compiler->fgFirstBB)->bbTreeList;
             JITDUMP("V%02u was live in\n", varNum);
-            DISPTREE(firstStmt);
             Interval * interval = getIntervalForLocalVar(varNum);
             RefPosition * pos = newRefPosition(interval, MinLocation, RefTypeZeroInit, firstStmt, 
                                                allRegs(interval->registerType));


### PR DESCRIPTION
- Add gtDispRange and gtDispTreeRange for displaying an LIR range
  and the LIR range covered by a tree node and the transitive
  closure of its operands, respectively.
- Add new macros, DISPRANGE and DISPTREERANGE, which wrap calls to
  the above methods s.t. they only execute in debug builds for
  methods specified by {Jit,Ngen}Dump.
- Change all uses of DISPTREE in the backend to whichever of
  DISPNODE and DISPTREERANGE is appropriate for each use.
- Add call argument location information to LIR dumps.
- Remove gtDispLinear*.
