### PR TITLE
Fix a couple of bugs in the LIR backend.

### DIFF
--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -579,6 +579,17 @@ void CodeGen::genCodeForBBlist()
         }
 
 #ifdef DEBUGGING_SUPPORT
+        // It is possible to reach the end of the block without generating code for the current IL offset.
+        // For example, if the following IR ends the current block, no code will have been generated for
+        // offset 21:
+        //
+        //          (  0,  0) [000040] ------------                il_offset void   IL offset: 21
+        //
+        //     N001 (  0,  0) [000039] ------------                nop       void
+        //
+        // This can lead to problems when debugging the generated code. To prevent these issues, make sure
+        // we've generated code for the last IL offset we saw in the block.
+        genEnsureCodeEmitted(currentILOffset);
 
         if (compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0))
         {

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -1820,6 +1820,17 @@ void CodeGen::genCodeForBBlist()
 #endif // defined(DEBUG) && defined(_TARGET_ARM64_)
 
 #ifdef DEBUGGING_SUPPORT
+        // It is possible to reach the end of the block without generating code for the current IL offset.
+        // For example, if the following IR ends the current block, no code will have been generated for
+        // offset 21:
+        //
+        //          (  0,  0) [000040] ------------                il_offset void   IL offset: 21
+        //
+        //     N001 (  0,  0) [000039] ------------                nop       void
+        //
+        // This can lead to problems when debugging the generated code. To prevent these issues, make sure
+        // we've generated code for the last IL offset we saw in the block.
+        genEnsureCodeEmitted(currentILOffset);
 
         if (compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0))
         {

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -759,6 +759,17 @@ void CodeGen::genCodeForBBlist()
 #endif // defined(DEBUG) && defined(LATE_DISASM) && defined(_TARGET_ARM64_)
 
 #ifdef DEBUGGING_SUPPORT
+        // It is possible to reach the end of the block without generating code for the current IL offset.
+        // For example, if the following IR ends the current block, no code will have been generated for
+        // offset 21:
+        //
+        //          (  0,  0) [000040] ------------                il_offset void   IL offset: 21
+        //
+        //     N001 (  0,  0) [000039] ------------                nop       void
+        //
+        // This can lead to problems when debugging the generated code. To prevent these issues, make sure
+        // we've generated code for the last IL offset we saw in the block.
+        genEnsureCodeEmitted(currentILOffset);
 
         if (compiler->opts.compScopeInfo && (compiler->info.compVarScopesCount > 0))
         {

--- a/src/jit/decomposelongs.cpp
+++ b/src/jit/decomposelongs.cpp
@@ -109,7 +109,7 @@ GenTree* DecomposeLongs::DecomposeNode(LIR::Use& use)
             {
                 printf("Changing implicit reference to lo half of long lclVar to an explicit reference of its promoted "
                        "half:\n");
-                m_compiler->gtDispTree(tree);
+                m_compiler->gtDispTreeRange(BlockRange(), tree);
             }
 #endif // DEBUG
             m_compiler->lvaDecRefCnts(tree);
@@ -129,7 +129,7 @@ GenTree* DecomposeLongs::DecomposeNode(LIR::Use& use)
     if (m_compiler->verbose)
     {
         printf("Decomposing TYP_LONG tree.  BEFORE:\n");
-        m_compiler->gtDispTree(tree);
+        m_compiler->gtDispTreeRange(BlockRange(), tree);
     }
 #endif // DEBUG
 
@@ -255,7 +255,7 @@ GenTree* DecomposeLongs::DecomposeNode(LIR::Use& use)
     {
         // NOTE: st_lcl_var doesn't dump properly afterwards.
         printf("Decomposing TYP_LONG tree.  AFTER:\n");
-        m_compiler->gtDispTree(use.Def());
+        m_compiler->gtDispTreeRange(BlockRange(), use.Def());
     }
 #endif
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -10047,7 +10047,9 @@ void Compiler::fgRemoveJTrue(BasicBlock* block)
         unsigned           sideEffects;
         LIR::ReadOnlyRange testRange = blockRange.GetTreeRange(test, &isClosed, &sideEffects);
 
-        if (isClosed && ((sideEffects & GTF_ALL_EFFECT) == 0))
+        // TODO(pdg): this should really be checking GTF_ALL_EFFECT, but that produces unacceptable
+        //            diffs compared to the existing backend.
+        if (isClosed && ((sideEffects & GTF_SIDE_EFFECT) == 0))
         {
             // If the jump and its operands form a contiguous, side-effect-free range,
             // remove them.
@@ -13798,7 +13800,9 @@ bool Compiler::fgOptimizeBranchToNext(BasicBlock* block, BasicBlock* bNext, Basi
             unsigned           sideEffects;
             LIR::ReadOnlyRange jmpRange = blockRange.GetTreeRange(jmp, &isClosed, &sideEffects);
 
-            if (isClosed && ((sideEffects & GTF_ALL_EFFECT) == 0))
+            // TODO(pdg): this should really be checking GTF_ALL_EFFECT, but that produces unacceptable
+            //            diffs compared to the existing backend.
+            if (isClosed && ((sideEffects & GTF_SIDE_EFFECT) == 0))
             {
                 // If the jump and its operands form a contiguous, side-effect-free range,
                 // remove them.

--- a/src/jit/gtlist.h
+++ b/src/jit/gtlist.h
@@ -198,7 +198,7 @@ GTNODE(STMT       , "stmtExpr"   ,0,GTK_SPECIAL|GTK_NOVALUE) // top-level list n
 GTNODE(RETURN     , "return"     ,0,GTK_UNOP|GTK_NOVALUE)    // return from current function
 GTNODE(SWITCH     , "switch"     ,0,GTK_UNOP|GTK_NOVALUE)    // switch
 
-GTNODE(NO_OP      , "no_op"      ,0,GTK_LEAF)    // nop!
+GTNODE(NO_OP      , "no_op"      ,0,GTK_LEAF|GTK_NOVALUE)    // nop!
 
 GTNODE(START_NONGC, "start_nongc",0,GTK_LEAF|GTK_NOVALUE)    // starts a new instruction group that will be non-gc interruptible
 


### PR DESCRIPTION
- GT_NO_OP was being considered as producing value, which it does not.
- All backends were missing a call to genEnsureCodeEmitted() after the
  final IL offset node in a block.
