### PR TITLE
Need to lower PHI stores to smash their TYP_SIMD12 types

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -3848,7 +3848,7 @@ void Lowering::LowerBlock(BasicBlock* block)
     //
     // See e.g. uses of InsertPInvoke{Method,Call}{Prolog,Epilog}.
 
-    GenTree* node = BlockRange().FirstNonPhiNode();
+    GenTree* node = BlockRange().FirstNode();
     while (node != nullptr)
     {
         node = LowerNode(node);


### PR DESCRIPTION
This avoids asserts later on.

@pgavlin PTAL
