### PR TITLE
Re-enable LSRA verification.

### DIFF
--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -613,8 +613,12 @@ private:
     void lsraDumpIntervals(const char* msg);
     void dumpRefPositions(const char* msg);
     void dumpVarRefPositions(const char* msg);
+
+    static bool IsResolutionMove(GenTree* node);
+    static bool IsResolutionNode(LIR::Range& containingRange, GenTree* node);
+
     void verifyFinalAllocation();
-    void verifyResolutionMove(GenTreeStmt* resolutionStmt, LsraLocation currentLocation);
+    void verifyResolutionMove(GenTree* resolutionNode, LsraLocation currentLocation);
 #else  // !DEBUG
     bool             doSelectNearest()
     {


### PR DESCRIPTION
This required adopting a different approach towards identifying whether or
not a particular node was part of a move inserted by LSRA resolution.
