### PR TITLE
Disable failing LONG tests for RyuJIT x86, issue #6778

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -371,6 +371,12 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b44410\b44410\b44410.cmd">
              <Issue>6588</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\basics\loopEH\loopEH.cmd">
+             <Issue>6778</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\superlong\_il_relsuperlong\_il_relsuperlong.cmd">
+             <Issue>6778</Issue>
+        </ExcludeList>
     </ItemGroup>
     
     <!-- Tests that need to be triaged for vararg usage as that is not supported -->


### PR DESCRIPTION
LIR exposed an existing issue, so we're disabling these failing
tests until that issue is resolved.

@pgavlin PTAL
