### PR TITLE
Fix the LSRA tuple-style dump for LIR.

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -17634,7 +17634,10 @@ BasicBlock* Compiler::fgRngChkTarget(BasicBlock* block, unsigned stkDepth, Speci
     if (verbose)
     {
         printf("*** Computing fgRngChkTarget for block BB%02u to stkDepth %d\n", block->bbNum, stkDepth);
-        gtDispTree(compCurStmt);
+        if (!block->IsLIR())
+        {
+            gtDispTree(compCurStmt);
+        }
     }
 #endif // DEBUG
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -11022,7 +11022,8 @@ void Compiler::gtDispTreeRange(LIR::Range& containingRange, GenTree* tree)
 //
 void Compiler::gtDispLIRNode(GenTree* node)
 {
-    auto displayOperand = [](GenTree* operand, const char* message, IndentInfo operandArc, IndentStack& indentStack) {
+    auto displayOperand = [](GenTree* operand, const char* message, IndentInfo operandArc, IndentStack& indentStack)
+    {
         assert(operand != nullptr);
         assert(message != nullptr);
 
@@ -11109,6 +11110,7 @@ void Compiler::gtDispLIRNode(GenTree* node)
                         }
 
                         displayOperand(operand, buf, operandArc, indentStack);
+                        operandArc = IIArc;
                     }
                 }
                 else
@@ -11132,6 +11134,8 @@ void Compiler::gtDispLIRNode(GenTree* node)
         {
             displayOperand(operand, "", operandArc, indentStack);
         }
+
+        operandArc = IIArc;
     }
 
     // Visit the operator
@@ -13169,7 +13173,7 @@ GenTreePtr Compiler::gtNewTempAssign(unsigned tmp, GenTreePtr val)
     }
 
 #ifndef LEGACY_BACKEND
-    if (fgOrder == FGOrderLinear)
+    if (compRationalIRForm)
     {
         Rationalizer::RewriteAssignmentIntoStoreLcl(asg->AsOp());
     }

--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -1039,7 +1039,7 @@ void Lowering::TreeNodeInfoInitCall(GenTreeCall* call)
             else
             {
 #ifdef DEBUG
-                compiler->gtDispTree(argNode);
+                compiler->gtDispTreeRange(BlockRange(), argNode);
 #endif
                 noway_assert(!"Unsupported TYP_STRUCT arg kind");
             }

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -3146,7 +3146,7 @@ void Lowering::LowerCmp(GenTreePtr tree)
                         {
                             printf("LowerCmp: Removing a GT_CAST to TYP_UBYTE and changing castOp1->gtType to "
                                    "TYP_UBYTE\n");
-                            comp->gtDispTree(tree);
+                            comp->gtDispTreeRange(BlockRange(), tree);
                         }
 #endif
                     }

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -939,6 +939,11 @@ private:
                               char*             operandString,
                               unsigned          operandStringLength);
     void lsraDispNode(GenTreePtr tree, LsraTupleDumpMode mode, bool hasDest);
+    void DumpOperandDefs(GenTree* operand,
+                         bool& first,
+                         LsraTupleDumpMode mode,
+                         char* operandString,
+                         const unsigned operandStringLength);
     void TupleStyleDump(LsraTupleDumpMode mode);
 
     bool         dumpTerse;


### PR DESCRIPTION
This dump would not have been correct in the face of IR that does not
obey the tree order invariant due to its use of a stack for operand
tracking.
