### PR TITLE
Introduce LIR::Range::Delete.

### DIFF
--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -4724,6 +4724,31 @@ inline static bool StructHasCustomLayout(DWORD attribs)
     return ((attribs & CORINFO_FLG_CUSTOMLAYOUT) != 0);
 }
 
+/*****************************************************************************
+ * This node should not be referenced by anyone now. Set its values to garbage
+ * to catch extra references
+ */
+
+inline void DEBUG_DESTROY_NODE(GenTreePtr tree)
+{
+#ifdef DEBUG
+    // printf("DEBUG_DESTROY_NODE for [0x%08x]\n", tree);
+
+    // Save gtOper in case we want to find out what this node was
+    tree->gtOperSave = tree->gtOper;
+
+    tree->gtType = TYP_UNDEF;
+    tree->gtFlags |= 0xFFFFFFFF & ~GTF_NODE_MASK;
+    if (tree->OperIsSimple())
+    {
+        tree->gtOp.gtOp1 = tree->gtOp.gtOp2 = nullptr;
+    }
+    // Must do this last, because the "gtOp" check above will fail otherwise.
+    // Don't call SetOper, because GT_COUNT is not a valid value
+    tree->gtOper = GT_COUNT;
+#endif
+}
+
 /*****************************************************************************/
 #endif //_COMPILER_HPP_
 /*****************************************************************************/

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -9963,8 +9963,7 @@ void Compiler::fgUnreachableBlock(BasicBlock* block)
         LIR::Range& blockRange = LIR::AsRange(block);
         if (!blockRange.IsEmpty())
         {
-            LIR::DecRefCnts(this, block, blockRange.NonPhiNodes());
-            blockRange.Remove(blockRange.FirstNode(), blockRange.LastNode());
+            blockRange.Delete(blockRange.FirstNode(), blockRange.LastNode(), block, this);
         }
     }
     else
@@ -10047,8 +10046,7 @@ void Compiler::fgRemoveJTrue(BasicBlock* block)
         {
             // If the jump and its operands form a contiguous, side-effect-free range,
             // remove them.
-            LIR::DecRefCnts(this, block, testRange);
-            blockRange.Remove(std::move(testRange));
+            blockRange.Delete(std::move(testRange), block, this);
         }
         else
         {
@@ -13392,8 +13390,7 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
             assert(isClosed);
             assert((sideEffects & GTF_ALL_EFFECT) == 0);
 
-            LIR::DecRefCnts(this, block, switchTreeRange);
-            blockRange->Remove(std::move(switchTreeRange));
+            blockRange->Delete(std::move(switchTreeRange), block, this);
         }
         else
         {
@@ -13784,8 +13781,7 @@ bool Compiler::fgOptimizeBranchToNext(BasicBlock* block, BasicBlock* bNext, Basi
             {
                 // If the jump and its operands form a contiguous, side-effect-free range,
                 // remove them.
-                LIR::DecRefCnts(this, block, jmpRange);
-                blockRange.Remove(std::move(jmpRange));
+                blockRange.Delete(std::move(jmpRange), block, this);
             }
             else
             {

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -9963,7 +9963,7 @@ void Compiler::fgUnreachableBlock(BasicBlock* block)
         LIR::Range& blockRange = LIR::AsRange(block);
         if (!blockRange.IsEmpty())
         {
-            blockRange.Delete(blockRange.FirstNode(), blockRange.LastNode(), block, this);
+            blockRange.Delete(this, block, blockRange.FirstNode(), blockRange.LastNode());
         }
     }
     else
@@ -10046,7 +10046,7 @@ void Compiler::fgRemoveJTrue(BasicBlock* block)
         {
             // If the jump and its operands form a contiguous, side-effect-free range,
             // remove them.
-            blockRange.Delete(std::move(testRange), block, this);
+            blockRange.Delete(this, block, std::move(testRange));
         }
         else
         {
@@ -13390,7 +13390,7 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
             assert(isClosed);
             assert((sideEffects & GTF_ALL_EFFECT) == 0);
 
-            blockRange->Delete(std::move(switchTreeRange), block, this);
+            blockRange->Delete(this, block, std::move(switchTreeRange));
         }
         else
         {
@@ -13781,7 +13781,7 @@ bool Compiler::fgOptimizeBranchToNext(BasicBlock* block, BasicBlock* bNext, Basi
             {
                 // If the jump and its operands form a contiguous, side-effect-free range,
                 // remove them.
-                blockRange.Delete(std::move(jmpRange), block, this);
+                blockRange.Delete(this, block, std::move(jmpRange));
             }
             else
             {

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -14406,6 +14406,11 @@ bool GenTree::IsRegOptional() const
 #endif
 }
 
+bool GenTree::IsPhiNode()
+{
+    return (OperGet() == GT_PHI_ARG) || (OperGet() == GT_PHI) || IsPhiDefn();
+}
+
 bool GenTree::IsPhiDefn()
 {
     bool res = ((OperGet() == GT_ASG) && (gtOp.gtOp2 != nullptr) && (gtOp.gtOp2->OperGet() == GT_PHI)) ||

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1748,6 +1748,9 @@ public:
     // register.
     bool IsRegOptional() const;
 
+    // Returns "true" iff "this" is a phi-related node (i.e. a GT_PHI_ARG, GT_PHI, or a PhiDefn).
+    bool IsPhiNode();
+
     // Returns "true" iff "*this" is an assignment (GT_ASG) tree that defines an SSA name (lcl = phi(...));
     bool IsPhiDefn();
 
@@ -1854,19 +1857,19 @@ public:
 };
 
 //------------------------------------------------------------------------
-// GenTreeOperandIterator: an iterator that will produce each operand of a
+// GenTreeUseEdgeIterator: an iterator that will produce each use edge of a
 //                         GenTree node in the order in which they are
-//                         used. Note that the operands of a node may not
+//                         used. Note that the use edges of a node may not
 //                         correspond exactly to the nodes on the other
 //                         ends of its use edges: in particular, GT_LIST
 //                         nodes are expanded into their component parts
 //                         (with the optional exception of multi-reg
 //                         arguments). This differs from the behavior of
-//                         GenTree::GetChild(), which does not expand
+//                         GenTree::GetChildPointer(), which does not expand
 //                         lists.
 //
 // Note: valid values of this type may be obtained by calling
-// `GenTree::OperandsBegin` and `GenTree::OperandsEnd`.
+// `GenTree::UseEdgesBegin` and `GenTree::UseEdgesEnd`.
 //
 class GenTreeUseEdgeIterator final
 {
@@ -1925,14 +1928,9 @@ public:
 //------------------------------------------------------------------------
 // GenTreeOperandIterator: an iterator that will produce each operand of a
 //                         GenTree node in the order in which they are
-//                         used. Note that the operands of a node may not
-//                         correspond exactly to the nodes on the other
-//                         ends of its use edges: in particular, GT_LIST
-//                         nodes are expanded into their component parts
-//                         (with the optional exception of multi-reg
-//                         arguments). This differs from the behavior of
-//                         GenTree::GetChild(), which does not expand
-//                         lists.
+//                         used. This uses `GenTreeUseEdgeIterator` under
+//                         the covers and comes with the same caveats
+//                         w.r.t. `GetChild`.
 //
 // Note: valid values of this type may be obtained by calling
 // `GenTree::OperandsBegin` and `GenTree::OperandsEnd`.

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -1076,7 +1076,7 @@ LIR::Range LIR::Range::Remove(ReadOnlyRange&& range)
 //    block - The block that contains the node, if any. May be null.
 //    compiler - The compiler context. May be null if block is null.
 //
-void LIR::Range::Delete(GenTree* node, BasicBlock* block, Compiler* compiler)
+void LIR::Range::Delete(Compiler* compiler, BasicBlock* block, GenTree* node)
 {
     assert(node != nullptr);
     assert((block == nullptr) == (compiler == nullptr));
@@ -1109,7 +1109,7 @@ void LIR::Range::Delete(GenTree* node, BasicBlock* block, Compiler* compiler)
 //    block - The block that contains the subrange, if any. May be null.
 //    compiler - The compiler context. May be null if block is null.
 //
-void LIR::Range::Delete(GenTree* firstNode, GenTree* lastNode, BasicBlock* block, Compiler* compiler)
+void LIR::Range::Delete(Compiler* compiler, BasicBlock* block, GenTree* firstNode, GenTree* lastNode)
 {
     assert(firstNode != nullptr);
     assert(lastNode != nullptr);
@@ -1154,9 +1154,9 @@ void LIR::Range::Delete(GenTree* firstNode, GenTree* lastNode, BasicBlock* block
 //    block - The block that contains the subrange, if any. May be null.
 //    compiler - The compiler context. May be null if block is null.
 //
-void LIR::Range::Delete(ReadOnlyRange&& range, BasicBlock* block, Compiler* compiler)
+void LIR::Range::Delete(Compiler* compiler, BasicBlock* block, ReadOnlyRange&& range)
 {
-    Delete(range.m_firstNode, range.m_lastNode, block, compiler);
+    Delete(compiler, block, range.m_firstNode, range.m_lastNode);
 }
 
 

--- a/src/jit/lir.cpp
+++ b/src/jit/lir.cpp
@@ -439,23 +439,12 @@ GenTree* LIR::Range::LastPhiNode() const
     GenTree* lastPhiNode = nullptr;
     for (GenTree* node : *this)
     {
-        if (node->OperGet() == GT_PHI_ARG)
+        if (!node->IsPhiNode())
         {
-            lastPhiNode = node;
-            continue;
-        }
-        else if (node->OperGet() == GT_PHI)
-        {
-            lastPhiNode = node;
-            continue;
-        }
-        else if (node->IsPhiDefn())
-        {
-            lastPhiNode = node;
-            continue;
+            break;
         }
 
-        break;
+        lastPhiNode = node;
     }
 
     return lastPhiNode;
@@ -470,20 +459,10 @@ GenTree* LIR::Range::FirstNonPhiNode() const
 {
     for (GenTree* node : *this)
     {
-        if (node->OperGet() == GT_PHI_ARG)
+        if (!node->IsPhiNode())
         {
-            continue;
+            return node;
         }
-        else if (node->OperGet() == GT_PHI)
-        {
-            continue;
-        }
-        else if (node->IsPhiDefn())
-        {
-            continue;
-        }
-
-        return node;
     }
 
     return nullptr;
@@ -1086,6 +1065,102 @@ LIR::Range LIR::Range::Remove(ReadOnlyRange&& range)
 }
 
 //------------------------------------------------------------------------
+// LIR::Range::Delete: Deletes a node from this range.
+//
+// Note that the deleted node must not be used after this function has
+// been called. If the deleted node is part of a block, this function also
+// calls `Compiler::lvaDecRefCnts` as necessary.
+//
+// Arguments:
+//    node - The node to delete. Must be part of this range.
+//    block - The block that contains the node, if any. May be null.
+//    compiler - The compiler context. May be null if block is null.
+//
+void LIR::Range::Delete(GenTree* node, BasicBlock* block, Compiler* compiler)
+{
+    assert(node != nullptr);
+    assert((block == nullptr) == (compiler == nullptr));
+
+    Remove(node);
+
+    if (block != nullptr)
+    {
+        if (((node->OperGet() == GT_CALL) && ((node->gtFlags & GTF_CALL_UNMANAGED) != 0)) ||
+            (node->OperIsLocal() && !node->IsPhiNode()))
+        {
+            compiler->lvaDecRefCnts(block, node);
+        }
+    }
+
+    DEBUG_DESTROY_NODE(node);
+}
+
+//------------------------------------------------------------------------
+// LIR::Range::Delete: Deletes a subrange from this range.
+//
+// Both the start and the end of the subrange must be part of this range.
+// Note that the deleted nodes must not be used after this function has
+// been called. If the deleted nodes are part of a block, this function
+// also calls `Compiler::lvaDecRefCnts` as necessary.
+//
+// Arguments:
+//    firstNode - The first node in the subrange.
+//    lastNode - The last node in the subrange.
+//    block - The block that contains the subrange, if any. May be null.
+//    compiler - The compiler context. May be null if block is null.
+//
+void LIR::Range::Delete(GenTree* firstNode, GenTree* lastNode, BasicBlock* block, Compiler* compiler)
+{
+    assert(firstNode != nullptr);
+    assert(lastNode != nullptr);
+    assert((block == nullptr) == (compiler == nullptr));
+
+    Remove(firstNode, lastNode);
+
+    assert(lastNode->gtNext == nullptr);
+
+    if (block != nullptr)
+    {
+        for (GenTree* node = firstNode; node != nullptr; node = node->gtNext)
+        {
+            if (((node->OperGet() == GT_CALL) && ((node->gtFlags & GTF_CALL_UNMANAGED) != 0)) ||
+                (node->OperIsLocal() && !node->IsPhiNode()))
+            {
+                compiler->lvaDecRefCnts(block, node);
+            }
+        }
+    }
+
+#ifdef DEBUG
+    // We can't do this in the loop above because it causes `IsPhiNode` to return a false negative
+    // for `GT_STORE_LCL_VAR` nodes that participate in phi definitions.
+    for (GenTree* node = firstNode; node != nullptr; node = node->gtNext)
+    {
+        DEBUG_DESTROY_NODE(node);
+    }
+#endif
+}
+
+//------------------------------------------------------------------------
+// LIR::Range::Delete: Deletes a subrange from this range.
+//
+// Both the start and the end of the subrange must be part of this range.
+// Note that the deleted nodes must not be used after this function has
+// been called. If the deleted nodes are part of a block, this function
+// also calls `Compiler::lvaDecRefCnts` as necessary.
+//
+// Arguments:
+//    range - The subrange to delete.
+//    block - The block that contains the subrange, if any. May be null.
+//    compiler - The compiler context. May be null if block is null.
+//
+void LIR::Range::Delete(ReadOnlyRange&& range, BasicBlock* block, Compiler* compiler)
+{
+    Delete(range.m_firstNode, range.m_lastNode, block, compiler);
+}
+
+
+//------------------------------------------------------------------------
 // LIR::Range::TryGetUse: Try to find the use for a given node.
 //
 // Arguments:
@@ -1516,16 +1591,4 @@ LIR::Range LIR::SeqTree(Compiler* compiler, GenTree* tree)
 
     compiler->gtSetEvalOrder(tree);
     return Range(compiler->fgSetTreeSeq(tree, nullptr, true), tree);
-}
-
-// TODO(pdg): this should probably just be folded into LIR::Range::Remove(ReadOnlyRange& range);
-void LIR::DecRefCnts(Compiler* compiler, BasicBlock* block, const ReadOnlyRange& range)
-{
-    for (GenTree* node : range)
-    {
-        if (((node->OperGet() == GT_CALL) && ((node->gtFlags & GTF_CALL_UNMANAGED) != 0)) || node->OperIsLocal())
-        {
-            compiler->lvaDecRefCnts(block, node);
-        }
-    }
 }

--- a/src/jit/lir.h
+++ b/src/jit/lir.h
@@ -282,6 +282,10 @@ public:
         Range Remove(GenTree* firstNode, GenTree* lastNode);
         Range Remove(ReadOnlyRange&& range);
 
+        void Delete(GenTree* node, BasicBlock* block, Compiler* compiler);
+        void Delete(GenTree* firstNode, GenTree* lastNode, BasicBlock* block, Compiler* compiler);
+        void Delete(ReadOnlyRange&& range, BasicBlock* block, Compiler* compiler);
+
         bool TryGetUse(GenTree* node, Use* use);
 
         ReadOnlyRange GetTreeRange(GenTree* root, bool* isClosed) const;
@@ -298,7 +302,6 @@ public:
 
     static Range EmptyRange();
     static Range SeqTree(Compiler* compiler, GenTree* tree);
-    static void DecRefCnts(Compiler* compiler, BasicBlock* block, const ReadOnlyRange& range);
 };
 
 #endif // _LIR_H_

--- a/src/jit/lir.h
+++ b/src/jit/lir.h
@@ -282,9 +282,9 @@ public:
         Range Remove(GenTree* firstNode, GenTree* lastNode);
         Range Remove(ReadOnlyRange&& range);
 
-        void Delete(GenTree* node, BasicBlock* block, Compiler* compiler);
-        void Delete(GenTree* firstNode, GenTree* lastNode, BasicBlock* block, Compiler* compiler);
-        void Delete(ReadOnlyRange&& range, BasicBlock* block, Compiler* compiler);
+        void Delete(Compiler* compiler, BasicBlock* block, GenTree* node);
+        void Delete(Compiler* compiler, BasicBlock* block, GenTree* firstNode, GenTree* lastNode);
+        void Delete(Compiler* compiler, BasicBlock* block, ReadOnlyRange&& range);
 
         bool TryGetUse(GenTree* node, Use* use);
 

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -2381,15 +2381,23 @@ bool Compiler::fgTryRemoveDeadLIRStore(LIR::Range& blockRange, GenTree* node, Ge
             *next = operandsRange.FirstNode()->gtPrev;
         }
 
-        // TODO(pdg): this scan should really be folded into LIR::Range::Remove().
-        LIR::DecRefCnts(this, compCurBB, operandsRange);
-        blockRange.Remove(std::move(operandsRange));
+        blockRange.Delete(std::move(operandsRange), compCurBB, this);
     }
 
-    blockRange.Remove(store);
-    if (store->IsLocal())
+    // If the store is marked as a late argument, it is referenced by a call. Instead of removing it,
+    // bash it to a NOP.
+    if ((store->gtFlags & GTF_LATE_ARG) != 0)
     {
-        lvaDecRefCnts(store);
+        if (store->IsLocal())
+        {
+            lvaDecRefCnts(compCurBB, store);
+        }
+
+        store->gtBashToNOP();
+    }
+    else
+    {
+        blockRange.Delete(store, compCurBB, this);
     }
 
     return true;

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -2381,7 +2381,7 @@ bool Compiler::fgTryRemoveDeadLIRStore(LIR::Range& blockRange, GenTree* node, Ge
             *next = operandsRange.FirstNode()->gtPrev;
         }
 
-        blockRange.Delete(std::move(operandsRange), compCurBB, this);
+        blockRange.Delete(this, compCurBB, std::move(operandsRange));
     }
 
     // If the store is marked as a late argument, it is referenced by a call. Instead of removing it,
@@ -2397,7 +2397,7 @@ bool Compiler::fgTryRemoveDeadLIRStore(LIR::Range& blockRange, GenTree* node, Ge
     }
     else
     {
-        blockRange.Delete(store, compCurBB, this);
+        blockRange.Delete(this, compCurBB, store);
     }
 
     return true;

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -113,31 +113,6 @@ GenTreePtr Compiler::fgMorphIntoHelperCall(GenTreePtr tree, int helper, GenTreeA
 }
 
 /*****************************************************************************
- * This node should not be referenced by anyone now. Set its values to garbage
- * to catch extra references
- */
-
-inline void DEBUG_DESTROY_NODE(GenTreePtr tree)
-{
-#ifdef DEBUG
-    // printf("DEBUG_DESTROY_NODE for [0x%08x]\n", tree);
-
-    // Save gtOper in case we want to find out what this node was
-    tree->gtOperSave = tree->gtOper;
-
-    tree->gtType = TYP_UNDEF;
-    tree->gtFlags |= 0xFFFFFFFF & ~GTF_NODE_MASK;
-    if (tree->OperIsSimple())
-    {
-        tree->gtOp.gtOp1 = tree->gtOp.gtOp2 = nullptr;
-    }
-    // Must do this last, because the "gtOp" check above will fail otherwise.
-    // Don't call SetOper, because GT_COUNT is not a valid value
-    tree->gtOper = GT_COUNT;
-#endif
-}
-
-/*****************************************************************************
  *
  *  Determine if a relop must be morphed to a qmark to manifest a boolean value.
  *  This is done when code generation can't create straight-line code to do it.

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -938,7 +938,7 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, ArrayStack<G
                 assert(isClosed);
                 assert((sideEffects & GTF_ALL_EFFECT) == 0);
 
-                BlockRange().Delete(std::move(lhsRange), m_block, comp);
+                BlockRange().Delete(comp, m_block, std::move(lhsRange));
             }
 
             GenTree* replacement = node->gtGetOp2();
@@ -961,7 +961,7 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, ArrayStack<G
                     assert(isClosed);
                     assert((sideEffects & GTF_ALL_EFFECT) == 0);
 
-                    BlockRange().Delete(std::move(rhsRange), m_block, comp);
+                    BlockRange().Delete(comp, m_block, std::move(rhsRange));
                 }
             }
 


### PR DESCRIPTION
This method combines the previous sequence of calls to Remove and
DecRefCnts into a single method. This method also calls
DEBUG_DESTROY_NODE on the deleted nodes.

This change revealed a bug in dead store removal: if a store in a
`gtCallArgs` list was found to be dead (this can with copy
propagation), the removed store was still referred to by the
`gtCallArgs` list. This change fixes that bug by bashing the store
to a NOP if it is marked with the `GTF_LATE_ARG` flag.
